### PR TITLE
Initial setup for identity provider tenant support

### DIFF
--- a/src/main/java/dev/sultanov/keycloak/multitenancy/authentication/requiredactions/SelectActiveTenant.java
+++ b/src/main/java/dev/sultanov/keycloak/multitenancy/authentication/requiredactions/SelectActiveTenant.java
@@ -1,9 +1,12 @@
 package dev.sultanov.keycloak.multitenancy.authentication.requiredactions;
 
 import dev.sultanov.keycloak.multitenancy.authentication.TenantsBean;
+import dev.sultanov.keycloak.multitenancy.authentication.TenantsBean.Tenant;
 import dev.sultanov.keycloak.multitenancy.model.TenantProvider;
 import dev.sultanov.keycloak.multitenancy.util.Constants;
 import jakarta.ws.rs.core.Response;
+
+import java.util.List;
 import java.util.stream.Collectors;
 import lombok.extern.jbosslog.JBossLog;
 import org.keycloak.Config;
@@ -24,6 +27,8 @@ public class SelectActiveTenant implements RequiredActionProvider, RequiredActio
         log.debug("Evaluating triggers for select active tenant action");
         var realm = context.getRealm();
         var user = context.getUser();
+        var attributes = user.getAttributes();
+        boolean hasExternalTenant = (attributes.containsKey("idp_tid") && attributes.containsKey("idp"));
         var authSessionNote = context.getAuthenticationSession().getUserSessionNotes().get(Constants.ACTIVE_TENANT_ID_SESSION_NOTE);
         var authResult = AuthenticationManager.authenticateIdentityCookie(context.getSession(), context.getRealm(), true);
         var userSessionNote = authResult != null ? authResult.getSession().getNote(Constants.ACTIVE_TENANT_ID_SESSION_NOTE) : null;
@@ -31,10 +36,17 @@ public class SelectActiveTenant implements RequiredActionProvider, RequiredActio
             log.debugf("No active tenant session note found");
             TenantProvider provider = context.getSession().getProvider(TenantProvider.class);
             var tenantMemberships = provider.getTenantMembershipsStream(realm, user).collect(Collectors.toList());
-            if (tenantMemberships.size() == 1) {
+            int members = tenantMemberships.size() + (hasExternalTenant ? 1 : 0);
+            if (members == 1) {
                 log.debugf("User is a member of a single tenant, setting active tenant automatically");
-                context.getAuthenticationSession().setUserSessionNote(Constants.ACTIVE_TENANT_ID_SESSION_NOTE, tenantMemberships.get(0).getTenant().getId());
-            } else if (tenantMemberships.size() > 1) {
+                if (hasExternalTenant) {
+                    context.getAuthenticationSession().setUserSessionNote(Constants.ACTIVE_TENANT_ID_SESSION_NOTE, attributes.get("idp_tid").get(0));
+                    context.getAuthenticationSession().setUserSessionNote(Constants.ACTIVE_TENANT_PROVIDER_SESSION_NOTE, attributes.get("idp").get(0));
+                } else {
+                    context.getAuthenticationSession().setUserSessionNote(Constants.ACTIVE_TENANT_ID_SESSION_NOTE, tenantMemberships.get(0).getTenant().getId());
+                    context.getAuthenticationSession().setUserSessionNote(Constants.ACTIVE_TENANT_PROVIDER_SESSION_NOTE, Constants.KEYCLOAK_TENANT_PROVIDER_CLAIM);
+                }
+            } else if (members > 1) {
                 log.debugf("Tenant selection is required, adding required action");
                 user.addRequiredAction(ID);
             }
@@ -45,17 +57,28 @@ public class SelectActiveTenant implements RequiredActionProvider, RequiredActio
     public void requiredActionChallenge(RequiredActionContext context) {
         var realm = context.getRealm();
         var user = context.getUser();
+        var attributes = user.getAttributes();
         var provider = context.getSession().getProvider(TenantProvider.class);
         var tenantMemberships = provider.getTenantMembershipsStream(realm, user).collect(Collectors.toList());
-        if (tenantMemberships.size() == 0) {
+        boolean hasExternalTenant = (attributes.containsKey("idp_tid") && attributes.containsKey("idp"));
+        int members = tenantMemberships.size() + (hasExternalTenant ? 1 : 0);
+        if (members == 0) {
             context.success();
-        } else if (tenantMemberships.size() == 1) {
+        } else if (members == 1) {
             log.debugf("User is a member of a single tenant, setting active tenant automatically");
-            context.getAuthenticationSession().setUserSessionNote(Constants.ACTIVE_TENANT_ID_SESSION_NOTE, tenantMemberships.get(0).getTenant().getId());
+            if (hasExternalTenant){
+                context.getAuthenticationSession().setUserSessionNote(Constants.ACTIVE_TENANT_ID_SESSION_NOTE, attributes.get("idp_tid").get(0));
+                context.getAuthenticationSession().setUserSessionNote(Constants.ACTIVE_TENANT_PROVIDER_SESSION_NOTE, attributes.get("idp").get(0));
+            } else {
+                context.getAuthenticationSession().setUserSessionNote(Constants.ACTIVE_TENANT_ID_SESSION_NOTE, tenantMemberships.get(0).getTenant().getId());
+                context.getAuthenticationSession().setUserSessionNote(Constants.ACTIVE_TENANT_PROVIDER_SESSION_NOTE, Constants.KEYCLOAK_TENANT_PROVIDER_CLAIM);
+            }
             context.success();
         } else {
             log.debug("Initializing challenge to select an active tenant");
-            Response challenge = context.form().setAttribute("data", TenantsBean.fromMembership(tenantMemberships)).createForm("select-tenant.ftl");
+            TenantsBean tenants = TenantsBean.fromMembership(tenantMemberships);
+            if (hasExternalTenant) tenants.getTenants().add(new Tenant(attributes.get("idp_tid").get(0), attributes.get("idp").get(0)));
+            Response challenge = context.form().setAttribute("data", tenants).createForm("select-tenant.ftl");
             context.challenge(challenge);
         }
     }
@@ -64,15 +87,23 @@ public class SelectActiveTenant implements RequiredActionProvider, RequiredActio
     public void processAction(RequiredActionContext context) {
         var realm = context.getRealm();
         var user = context.getUser();
+        var attributes = user.getAttributes();
         var provider = context.getSession().getProvider(TenantProvider.class);
         var memberships = provider.getTenantMembershipsStream(realm, user).collect(Collectors.toList());
+        boolean hasExternalTenant = (attributes.containsKey("idp_tid") && attributes.containsKey("idp"));
 
         var formData = context.getHttpRequest().getDecodedFormParameters();
-        var selectedTenant = formData.getFirst("tenant");
+        String selectedTenant = formData.getFirst("tenant");
 
         if (memberships.stream().anyMatch(membership -> membership.getTenant().getId().equals(selectedTenant))) {
             log.debugf("Active tenant selected %s, setting session note", selectedTenant);
             context.getAuthenticationSession().setUserSessionNote(Constants.ACTIVE_TENANT_ID_SESSION_NOTE, selectedTenant);
+            context.getAuthenticationSession().setUserSessionNote(Constants.ACTIVE_TENANT_PROVIDER_SESSION_NOTE, Constants.KEYCLOAK_TENANT_PROVIDER_CLAIM);
+            context.success();
+        } else if (hasExternalTenant && selectedTenant.equals(attributes.get("idp_tid").get(0))){
+            log.debugf("Active tenant selected %s, setting session note", selectedTenant);
+            context.getAuthenticationSession().setUserSessionNote(Constants.ACTIVE_TENANT_ID_SESSION_NOTE, selectedTenant);
+            context.getAuthenticationSession().setUserSessionNote(Constants.ACTIVE_TENANT_PROVIDER_SESSION_NOTE, attributes.get("idp").get(0));
             context.success();
         } else {
             log.warnf("User %s is not a member of the selected tenant %s", user.getId(), selectedTenant);

--- a/src/main/java/dev/sultanov/keycloak/multitenancy/protocol/oidc/mappers/ActiveTenantMapper.java
+++ b/src/main/java/dev/sultanov/keycloak/multitenancy/protocol/oidc/mappers/ActiveTenantMapper.java
@@ -4,6 +4,8 @@ import dev.sultanov.keycloak.multitenancy.model.TenantProvider;
 import dev.sultanov.keycloak.multitenancy.util.Constants;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ProtocolMapperModel;
@@ -69,6 +71,9 @@ public class ActiveTenantMapper extends AbstractOIDCProtocolMapper implements OI
         } else if (tenantProvider instanceof String && tenantProvider.length() > 0) {
             List<String> roles = userSession.getUser().getAttributes().get("idp_roles");
             roles = (roles != null) ? roles : new ArrayList<String>();
+            roles = roles.stream()
+                    .filter(role -> !role.equals(Constants.TENANT_ADMIN_ROLE))
+                    .collect(Collectors.toList());
             var claimName = mappingModel.getConfig().get(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME);
             token.getOtherClaims().put(claimName, ClaimsFactory.toClaim(activeTenantId, tenantProvider, roles));
         }

--- a/src/main/java/dev/sultanov/keycloak/multitenancy/protocol/oidc/mappers/ClaimsFactory.java
+++ b/src/main/java/dev/sultanov/keycloak/multitenancy/protocol/oidc/mappers/ClaimsFactory.java
@@ -1,8 +1,12 @@
 package dev.sultanov.keycloak.multitenancy.protocol.oidc.mappers;
 
 import dev.sultanov.keycloak.multitenancy.model.TenantMembershipModel;
+import dev.sultanov.keycloak.multitenancy.util.Constants;
+
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 
 public class ClaimsFactory {
@@ -10,12 +14,23 @@ public class ClaimsFactory {
     private static final String TENANT_ID_KEY = "tenant_id";
     private static final String TENANT_NAME_KEY = "tenant_name";
     private static final String ROLES_KEY = "roles";
+    private static final String PROVIDER_KEY = "provider";
 
     static Map<String, Object> toClaim(TenantMembershipModel membership) {
         Map<String, Object> claim = new HashMap<>();
         claim.put(TENANT_ID_KEY, membership.getTenant().getId());
         claim.put(TENANT_NAME_KEY, membership.getTenant().getName());
         claim.put(ROLES_KEY, membership.getRoles());
+        claim.put(PROVIDER_KEY, Constants.KEYCLOAK_TENANT_PROVIDER_CLAIM);
+        return Collections.unmodifiableMap(claim);
+    }
+
+    static Map<String, Object> toClaim(String tenantId, String tenantProvider, List<String> roles) {
+        Map<String, Object> claim = new HashMap<>();
+        claim.put(TENANT_ID_KEY, tenantId);
+        claim.put(TENANT_NAME_KEY, "");
+        claim.put(ROLES_KEY, new HashSet<String>(roles));
+        claim.put(PROVIDER_KEY, tenantProvider);
         return Collections.unmodifiableMap(claim);
     }
 

--- a/src/main/java/dev/sultanov/keycloak/multitenancy/util/Constants.java
+++ b/src/main/java/dev/sultanov/keycloak/multitenancy/util/Constants.java
@@ -4,6 +4,8 @@ public class Constants {
 
     public static final String TENANT_ADMIN_ROLE = "tenant-admin";
     public static final String ACTIVE_TENANT_ID_SESSION_NOTE = "active-tenant-id";
+    public static final String ACTIVE_TENANT_PROVIDER_SESSION_NOTE = "active-tenant-provider";
+    public static final String KEYCLOAK_TENANT_PROVIDER_CLAIM = "keycloak";
 
     private Constants() {
         throw new AssertionError();


### PR DESCRIPTION
This allows users to select identity provider tenants instead of internally created tenants.

## Features
- Active token claim mapper now includes an additional claim called "provider"
- Users do not need to create a tenant or get invited to one during on-boarding
- All management of users, roles and invitations can be done outside of Keycloak

## Compatibility
These changes should be backwards compatible with the intended use of this extension. For these new features to become active Keycloak admins need to add additional mappings for identity providers.

## Configure
Each identity provider need mappers to activate the option for users to login with their identity provider tenant.
In your realms admin console, go to `Authentication` > `Required actions` and enable all the following actions (note that they must be placed exactly in this order):
* Review tenant invitations
* Select active tenant

Note: The following action has not been tested with this code change. Creating internal tenants was done through the keycloak-multi-tenancy API using a service account.
* Create tenant

In your realms admin console, go to `Identity providers` > `Select a provider` > `Mappers` > `Add mapper` and add the following mappers to activate external tenants. This example uses Entra ID (Azure AD) as identity and tenant provider. Register the App inside Entra ID as a multitenant web app (Any Microsoft Entra ID tenant - Multitenant)
```
Mapper name: Microsoft organization tenant immutable identifier
Mapper type: Attribute Importer
Sync mode override: Force
Claim: tid
User Attribute Name: idp_tid
```
```
Mapper name: Microsoft organization tenant roles
Mapper type: Attribute Importer
Sync mode override: Force
Claim: wids
User Attribute Name: idp_roles
```
```
Mapper name: Microsoft identity provider alias
Mapper type: Hardcoded Attribute
Sync mode override: Force
User Attribute: idp
User Attribute Value: microsoft
```

This is how the active tenant mapper will look like when users choose to login with their external tenant. Note: active_tenant.provider will be "keycloak" when users login with internal tenants
```
"active_tenant": {
    "tenant_id": "e2b004fd-04c3-4b7a-acd0-4d997eb5cefa",
    "tenant_name": "",
    "provider": "microsoft",
    "roles": [
      "b79fbf4d-3ef9-4689-8143-76b194e85509",
      "62e90394-69f5-4237-9190-012177145e10"
    ]
  }
```

## Development
This feature need to be tested and could potentially be improved. All input is welcome. The current state of the code proposal is "usable". 

## Future Improvements
* Find a way to map tenant name
* All mappers use "user attributes" but could potentially use "user session notes"