### PR TITLE
feature: Add support for tenant-specific identity providers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <name>Keycloak Multi-Tenancy</name>
 
     <properties>
-        <keycloak.version>22.0.3</keycloak.version>
+        <keycloak.version>22.0.5</keycloak.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/dev/sultanov/keycloak/multitenancy/authentication/IdentityProviderTenantsConfig.java
+++ b/src/main/java/dev/sultanov/keycloak/multitenancy/authentication/IdentityProviderTenantsConfig.java
@@ -1,0 +1,29 @@
+package dev.sultanov.keycloak.multitenancy.authentication;
+
+import java.util.Arrays;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Value;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.utils.StringUtil;
+
+@Value
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class IdentityProviderTenantsConfig {
+
+    public static final String IDENTITY_PROVIDER_TENANTS = "multi-tenancy.tenants";
+
+    boolean tenantsSpecific;
+    Set<String> accessibleTenantIds;
+
+    public static IdentityProviderTenantsConfig of(IdentityProviderModel identityProviderModel) {
+        var configValue = identityProviderModel.getConfig().get(IDENTITY_PROVIDER_TENANTS);
+        if (StringUtil.isBlank(configValue)) {
+            return new IdentityProviderTenantsConfig(false, Set.of());
+        } else {
+            var tenantIds = configValue.split(",");
+            return new IdentityProviderTenantsConfig(true, Set.copyOf(Arrays.asList(tenantIds)));
+        }
+    }
+}

--- a/src/main/java/dev/sultanov/keycloak/multitenancy/authentication/authenticators/IdpTenantMembershipsCreatingAuthenticator.java
+++ b/src/main/java/dev/sultanov/keycloak/multitenancy/authentication/authenticators/IdpTenantMembershipsCreatingAuthenticator.java
@@ -1,0 +1,96 @@
+package dev.sultanov.keycloak.multitenancy.authentication.authenticators;
+
+import dev.sultanov.keycloak.multitenancy.authentication.IdentityProviderTenantsConfig;
+import dev.sultanov.keycloak.multitenancy.model.TenantProvider;
+import dev.sultanov.keycloak.multitenancy.util.Constants;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import java.util.Optional;
+import java.util.Set;
+import lombok.extern.jbosslog.JBossLog;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.AuthenticationFlowException;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.authenticators.broker.AbstractIdpAuthenticator;
+import org.keycloak.authentication.authenticators.broker.util.PostBrokerLoginConstants;
+import org.keycloak.authentication.authenticators.broker.util.SerializedBrokeredIdentityContext;
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+
+@JBossLog
+public class IdpTenantMembershipsCreatingAuthenticator implements Authenticator {
+
+    public void authenticate(AuthenticationFlowContext context) {
+        var authSession = context.getAuthenticationSession();
+
+        var firstLoginCtx = SerializedBrokeredIdentityContext.readFromAuthenticationSession(authSession, AbstractIdpAuthenticator.BROKERED_CONTEXT_NOTE);
+        var postLoginCtx = SerializedBrokeredIdentityContext.readFromAuthenticationSession(authSession, PostBrokerLoginConstants.PBL_BROKERED_IDENTITY_CONTEXT);
+        var serializedCtx = Optional.ofNullable(firstLoginCtx).orElse(postLoginCtx);
+
+        if (serializedCtx == null) {
+            throw new AuthenticationFlowException("Not found serialized context in clientSession", AuthenticationFlowError.IDENTITY_PROVIDER_ERROR);
+        } else {
+            BrokeredIdentityContext brokerContext = serializedCtx.deserialize(context.getSession(), authSession);
+            if (!brokerContext.getIdpConfig().isEnabled()) {
+                context.getEvent().user(context.getUser()).error("identity_provider_error");
+                var challengeResponse = context.form().setError("identityProviderUnexpectedErrorMessage").createErrorPage(Status.BAD_REQUEST);
+                context.failureChallenge(AuthenticationFlowError.IDENTITY_PROVIDER_ERROR, challengeResponse);
+            }
+
+            this.doAuthenticate(context, brokerContext);
+        }
+    }
+
+    private void doAuthenticate(AuthenticationFlowContext context, BrokeredIdentityContext brokerContext) {
+        log.debug("Evaluating the requirement to create tenant memberships");
+
+        var idpTenantsConfig = IdentityProviderTenantsConfig.of(brokerContext.getIdpConfig());
+        if (idpTenantsConfig.isTenantsSpecific()) {
+            log.debug("Creating memberships for the following tenants: " + idpTenantsConfig.getAccessibleTenantIds());
+
+            var realm = context.getRealm();
+            var user = context.getUser();
+            var provider = context.getSession().getProvider(TenantProvider.class);
+            for (String tenantId : idpTenantsConfig.getAccessibleTenantIds()) {
+                var tenantById = provider.getTenantById(realm, tenantId);
+                if (tenantById.isEmpty()) {
+                    log.warn("Tenant with ID %s, configured in IDP with alias %s, does not exist. Skipping membership creation."
+                            .formatted(tenantId, brokerContext.getIdpConfig().getAlias()));
+                } else if (tenantById.get().getMembership(user).isPresent()) {
+                    log.debug("User is already a member of tenant with ID %s. Skipping membership creation.".formatted(tenantId));
+                } else {
+                    tenantById.get().grantMembership(user, Set.of(Constants.TENANT_USER_ROLE));
+                    log.debug("Membership created in tenant with ID %s".formatted(tenantId));
+                }
+            }
+        } else {
+            log.debug("The Identity Provider is not tenant-specific, so there's no need to create memberships.");
+        }
+        context.success();
+    }
+
+    public void action(AuthenticationFlowContext context) {
+        authenticate(context);
+    }
+
+    public boolean requiresUser() {
+        return true;
+    }
+
+    public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+        return true;
+    }
+
+    @Override
+    public void setRequiredActions(KeycloakSession keycloakSession, RealmModel realmModel, UserModel userModel) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/src/main/java/dev/sultanov/keycloak/multitenancy/authentication/authenticators/IdpTenantMembershipsCreatingAuthenticatorFactory.java
+++ b/src/main/java/dev/sultanov/keycloak/multitenancy/authentication/authenticators/IdpTenantMembershipsCreatingAuthenticatorFactory.java
@@ -1,0 +1,65 @@
+package dev.sultanov.keycloak.multitenancy.authentication.authenticators;
+
+import static dev.sultanov.keycloak.multitenancy.authentication.IdentityProviderTenantsConfig.IDENTITY_PROVIDER_TENANTS;
+
+import java.util.List;
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+public class IdpTenantMembershipsCreatingAuthenticatorFactory implements AuthenticatorFactory {
+
+    public static final String PROVIDER_ID = "idp-tenant-memberships";
+
+    private static final IdpTenantMembershipsCreatingAuthenticator SINGLETON = new IdpTenantMembershipsCreatingAuthenticator();
+
+    public Authenticator create(KeycloakSession session) {
+        return SINGLETON;
+    }
+
+    public void init(Config.Scope config) {
+    }
+
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    public void close() {
+    }
+
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    public String getReferenceCategory() {
+        return "multiTenancy";
+    }
+
+    public boolean isConfigurable() {
+        return false;
+    }
+
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return REQUIREMENT_CHOICES;
+    }
+
+    public String getDisplayType() {
+        return "Create tenant memberships";
+    }
+
+    public String getHelpText() {
+        return "Automatically create tenant memberships for users based on Identity Provider configuration property: " + IDENTITY_PROVIDER_TENANTS;
+    }
+
+
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return null;
+    }
+
+    public boolean isUserSetupAllowed() {
+        return false;
+    }
+}

--- a/src/main/java/dev/sultanov/keycloak/multitenancy/authentication/requiredactions/SelectActiveTenant.java
+++ b/src/main/java/dev/sultanov/keycloak/multitenancy/authentication/requiredactions/SelectActiveTenant.java
@@ -1,12 +1,20 @@
 package dev.sultanov.keycloak.multitenancy.authentication.requiredactions;
 
+import static dev.sultanov.keycloak.multitenancy.util.Constants.IDENTITY_PROVIDER_SESSION_NOTE;
+
+import dev.sultanov.keycloak.multitenancy.authentication.IdentityProviderTenantsConfig;
 import dev.sultanov.keycloak.multitenancy.authentication.TenantsBean;
+import dev.sultanov.keycloak.multitenancy.model.TenantMembershipModel;
 import dev.sultanov.keycloak.multitenancy.model.TenantProvider;
 import dev.sultanov.keycloak.multitenancy.util.Constants;
 import jakarta.ws.rs.core.Response;
-import java.util.stream.Collectors;
+import jakarta.ws.rs.core.Response.Status;
+import java.util.List;
+import java.util.Optional;
 import lombok.extern.jbosslog.JBossLog;
 import org.keycloak.Config;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.AuthenticationFlowException;
 import org.keycloak.authentication.RequiredActionContext;
 import org.keycloak.authentication.RequiredActionFactory;
 import org.keycloak.authentication.RequiredActionProvider;
@@ -22,31 +30,24 @@ public class SelectActiveTenant implements RequiredActionProvider, RequiredActio
     @Override
     public void evaluateTriggers(RequiredActionContext context) {
         log.debug("Evaluating triggers for select active tenant action");
-        var realm = context.getRealm();
-        var user = context.getUser();
-        var authSessionNote = context.getAuthenticationSession().getUserSessionNotes().get(Constants.ACTIVE_TENANT_ID_SESSION_NOTE);
-        var authResult = AuthenticationManager.authenticateIdentityCookie(context.getSession(), context.getRealm(), true);
-        var userSessionNote = authResult != null ? authResult.getSession().getNote(Constants.ACTIVE_TENANT_ID_SESSION_NOTE) : null;
-        if (authSessionNote == null && userSessionNote == null) {
-            log.debugf("No active tenant session note found");
-            TenantProvider provider = context.getSession().getProvider(TenantProvider.class);
-            var tenantMemberships = provider.getTenantMembershipsStream(realm, user).collect(Collectors.toList());
-            if (tenantMemberships.size() == 1) {
-                log.debugf("User is a member of a single tenant, setting active tenant automatically");
-                context.getAuthenticationSession().setUserSessionNote(Constants.ACTIVE_TENANT_ID_SESSION_NOTE, tenantMemberships.get(0).getTenant().getId());
-            } else if (tenantMemberships.size() > 1) {
-                log.debugf("Tenant selection is required, adding required action");
-                user.addRequiredAction(ID);
-            }
+        if (getSessionNote(context, Constants.ACTIVE_TENANT_ID_SESSION_NOTE).isPresent()) {
+            return;
+        }
+
+        log.debug("No active tenant session note found");
+        var tenantMemberships = getFilteredTenantMemberships(context);
+        if (tenantMemberships.size() == 1) {
+            log.debug("User is a member of a single tenant, setting active tenant automatically");
+            context.getAuthenticationSession().setUserSessionNote(Constants.ACTIVE_TENANT_ID_SESSION_NOTE, tenantMemberships.get(0).getTenant().getId());
+        } else if (tenantMemberships.size() > 1) {
+            log.debug("Tenant selection is required, adding required action");
+            context.getUser().addRequiredAction(ID);
         }
     }
 
     @Override
     public void requiredActionChallenge(RequiredActionContext context) {
-        var realm = context.getRealm();
-        var user = context.getUser();
-        var provider = context.getSession().getProvider(TenantProvider.class);
-        var tenantMemberships = provider.getTenantMembershipsStream(realm, user).collect(Collectors.toList());
+        var tenantMemberships = getFilteredTenantMemberships(context);
         if (tenantMemberships.size() == 0) {
             context.success();
         } else if (tenantMemberships.size() == 1) {
@@ -65,7 +66,7 @@ public class SelectActiveTenant implements RequiredActionProvider, RequiredActio
         var realm = context.getRealm();
         var user = context.getUser();
         var provider = context.getSession().getProvider(TenantProvider.class);
-        var memberships = provider.getTenantMembershipsStream(realm, user).collect(Collectors.toList());
+        var memberships = provider.getTenantMembershipsStream(realm, user).toList();
 
         var formData = context.getHttpRequest().getDecodedFormParameters();
         var selectedTenant = formData.getFirst("tenant");
@@ -107,4 +108,55 @@ public class SelectActiveTenant implements RequiredActionProvider, RequiredActio
     public void close() {
     }
 
+    /**
+     * Retrieves and filters the tenant memberships based on Identity Provider configuration.
+     */
+    private List<TenantMembershipModel> getFilteredTenantMemberships(RequiredActionContext context) {
+        var idpTenantsConfig = getIdentityProviderTenantsConfig(context);
+        var provider = context.getSession().getProvider(TenantProvider.class);
+        var tenantMembershipsStream = provider.getTenantMembershipsStream(context.getRealm(), context.getUser());
+        if (idpTenantsConfig.isPresent() && idpTenantsConfig.get().isTenantsSpecific()) {
+            log.debug("Filtering tenant memberships based on Identity Provider configuration");
+            var tenantMembershipModels = tenantMembershipsStream.filter(
+                            membership -> idpTenantsConfig.get().getAccessibleTenantIds().contains(membership.getTenant().getId()))
+                    .toList();
+            if (tenantMembershipModels.size() == 0) {
+                throw new AuthenticationFlowException("User does not have access to any of IDP tenants", AuthenticationFlowError.ACCESS_DENIED);
+            }
+            return tenantMembershipModels;
+        } else {
+            log.debug("Filtering not required based on Identity Provider configuration");
+            return tenantMembershipsStream.toList();
+        }
+    }
+
+    /**
+     * Retrieves the optional Identity Provider based on the available session data and returns its configuration.
+     *
+     * @see <a href="https://www.keycloak.org/docs/latest/server_admin/#available-user-session-data">Keycloak Documentation - Available User Session Data</a>
+     */
+    private Optional<IdentityProviderTenantsConfig> getIdentityProviderTenantsConfig(RequiredActionContext context) {
+        return getSessionNote(context, IDENTITY_PROVIDER_SESSION_NOTE)
+                .map(context.getRealm()::getIdentityProviderByAlias)
+                .map(IdentityProviderTenantsConfig::of);
+    }
+
+    /**
+     * When a user first opens a browser and wants to authenticate, an authentication session is created. This auth session is used throughout the entire
+     * authentication process. After successful authentication, a user session is created, and the notes from authentication session are set to the user
+     * session.
+     * <p>
+     * When the same user wants to authenticate again in the same browser session, automatic Single Sign-On (SSO) takes place. This results in the creation of a
+     * completely new authentication session. However, the user session remains the same and is shared among all authentication sessions in the same browser
+     * session.
+     * <p>
+     * Therefore, for subsequent SSO authentications, it's necessary to retrieve the notes from the user session.
+     */
+    private Optional<String> getSessionNote(RequiredActionContext context, String key) {
+        var authSessionNote = Optional.ofNullable(context.getAuthenticationSession().getUserSessionNotes().get(key));
+        var userSessionNote = Optional.ofNullable(AuthenticationManager.authenticateIdentityCookie(context.getSession(), context.getRealm(), true))
+                .map(authResult -> authResult.getSession().getNote(key));
+
+        return authSessionNote.or(() -> userSessionNote);
+    }
 }

--- a/src/main/java/dev/sultanov/keycloak/multitenancy/util/Constants.java
+++ b/src/main/java/dev/sultanov/keycloak/multitenancy/util/Constants.java
@@ -3,7 +3,10 @@ package dev.sultanov.keycloak.multitenancy.util;
 public class Constants {
 
     public static final String TENANT_ADMIN_ROLE = "tenant-admin";
+    public static final String TENANT_USER_ROLE = "tenant-user";
+
     public static final String ACTIVE_TENANT_ID_SESSION_NOTE = "active-tenant-id";
+    public static final String IDENTITY_PROVIDER_SESSION_NOTE = "identity_provider";
 
     private Constants() {
         throw new AssertionError();

--- a/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -1,0 +1,1 @@
+dev.sultanov.keycloak.multitenancy.authentication.authenticators.IdpTenantMembershipsCreatingAuthenticatorFactory

--- a/src/test/java/dev/sultanov/keycloak/multitenancy/ApiIntegrationTest.java
+++ b/src/test/java/dev/sultanov/keycloak/multitenancy/ApiIntegrationTest.java
@@ -20,7 +20,7 @@ public class ApiIntegrationTest extends BaseIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        keycloakAdminClient = KeycloakAdminCli.create();
+        keycloakAdminClient = KeycloakAdminCli.forMainRealm();
     }
 
     @Test

--- a/src/test/java/dev/sultanov/keycloak/multitenancy/BrowserIntegrationTest.java
+++ b/src/test/java/dev/sultanov/keycloak/multitenancy/BrowserIntegrationTest.java
@@ -21,7 +21,7 @@ public class BrowserIntegrationTest extends BaseIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        keycloakAdminClient = KeycloakAdminCli.create();
+        keycloakAdminClient = KeycloakAdminCli.forMainRealm();
     }
 
     @Test

--- a/src/test/java/dev/sultanov/keycloak/multitenancy/IdentityProviderIntegrationTest.java
+++ b/src/test/java/dev/sultanov/keycloak/multitenancy/IdentityProviderIntegrationTest.java
@@ -1,0 +1,322 @@
+package dev.sultanov.keycloak.multitenancy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.sultanov.keycloak.multitenancy.resource.representation.TenantInvitationRepresentation;
+import dev.sultanov.keycloak.multitenancy.resource.representation.TenantRepresentation;
+import dev.sultanov.keycloak.multitenancy.support.BaseIntegrationTest;
+import dev.sultanov.keycloak.multitenancy.support.IntegrationTestContextHolder;
+import dev.sultanov.keycloak.multitenancy.support.actor.KeycloakAdminCli;
+import dev.sultanov.keycloak.multitenancy.support.browser.AccountPage;
+import dev.sultanov.keycloak.multitenancy.support.browser.CreateTenantPage;
+import dev.sultanov.keycloak.multitenancy.support.browser.ErrorPage;
+import dev.sultanov.keycloak.multitenancy.support.browser.ReviewInvitationsPage;
+import dev.sultanov.keycloak.multitenancy.support.browser.SelectTenantPage;
+import dev.sultanov.keycloak.multitenancy.support.data.FakerProvider;
+import dev.sultanov.keycloak.multitenancy.support.data.TenantData;
+import dev.sultanov.keycloak.multitenancy.support.data.UserData;
+import jakarta.annotation.Nullable;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.CreatedResponseUtil;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+
+public class IdentityProviderIntegrationTest extends BaseIntegrationTest {
+
+    private static final String FIRST_LOGIN_FLOW_WITH_MEMBERSHIP_CREATION = "first broker login with tenant membership creation";
+    private static final String FIRST_LOGIN_FLOW_WITHOUT_MEMBERSHIP_CREATION = "first broker login without tenant membership creation";
+    private static final String POST_LOGIN_MEMBERSHIP_CREATION = "create tenant memberships only";
+
+    private KeycloakAdminCli mainRealmClient;
+    private KeycloakAdminCli idpRealmClient;
+
+    private String idpAlias;
+
+    @BeforeEach
+    void setUp() {
+        mainRealmClient = KeycloakAdminCli.forMainRealm();
+        idpRealmClient = KeycloakAdminCli.forIdpRealm();
+    }
+
+    @AfterEach
+    void tearDown() {
+        deleteIdentityProvider(idpAlias);
+    }
+
+    @Test
+    void shouldRequireToCreateTenant_whenSignInUsingPublicIdpAndNotMemberOfAnyTenants() {
+        // given
+        var idpUser = idpRealmClient.createVerifiedUser();
+        idpAlias = createFirstLoginMembershipCreationIdp(Set.of());
+
+        // when
+        var nextPage = AccountPage.open()
+                .signIn()
+                .signInWith(idpAlias)
+                .fillCredentials(idpUser.getUserData().getEmail(), idpUser.getUserData().getPassword())
+                .signIn();
+        assertThat(nextPage).isInstanceOf(CreateTenantPage.class);
+
+        // then
+        nextPage = ((CreateTenantPage) nextPage).fillTenantData(TenantData.random()).submit();
+        assertThat(nextPage).isInstanceOf(AccountPage.class);
+        assertThat(((AccountPage) nextPage).getLoggedInUser()).contains(idpUser.getUserData().getFullName());
+    }
+
+    @Test
+    void shouldAutomaticallySignIn_whenSignInUsingPublicIdpAndMemberOfOneTenant() {
+        // given
+        var multiTenantUser = createMultiTenantUser();
+        var idpUser = idpRealmClient.createVerifiedUser(multiTenantUser.getKey());
+        idpAlias = createFirstLoginMembershipCreationIdp(Set.of());
+
+        // when
+        var nextPage = AccountPage.open()
+                .signIn()
+                .signInWith(idpAlias)
+                .fillCredentials(idpUser.getUserData().getEmail(), idpUser.getUserData().getPassword())
+                .signIn();
+
+        // then
+        assertThat(nextPage).isInstanceOf(SelectTenantPage.class);
+        assertThat(((SelectTenantPage) nextPage).availableOptions()).containsExactlyInAnyOrderElementsOf(
+                multiTenantUser.getValue().stream().map(TenantRepresentation::getName).toList()
+        );
+    }
+
+    @Test
+    void shouldShowTenantSelection_whenSignInUsingPublicIdpAndMemberOfMultipleTenants() {
+        // given
+        var multiTenantUser = createMultiTenantUser();
+        var idpUser = idpRealmClient.createVerifiedUser(multiTenantUser.getKey());
+        idpAlias = createFirstLoginMembershipCreationIdp(Set.of());
+
+        // when
+        var nextPage = AccountPage.open()
+                .signIn()
+                .signInWith(idpAlias)
+                .fillCredentials(idpUser.getUserData().getEmail(), idpUser.getUserData().getPassword())
+                .signIn();
+
+        // then
+        assertThat(nextPage).isInstanceOf(SelectTenantPage.class);
+        assertThat(((SelectTenantPage) nextPage).availableOptions()).containsExactlyInAnyOrderElementsOf(
+                multiTenantUser.getValue().stream().map(TenantRepresentation::getName).toList()
+        );
+    }
+
+    @Test
+    void shouldCreateMissingMembership_whenSignInUsingTenantIdpWithFirstLoginTenantMembershipCreation() {
+        // given
+        var multiTenantUser = createMultiTenantUser();
+        var idpUser = idpRealmClient.createVerifiedUser(multiTenantUser.getKey());
+
+        var idpTenant1 = multiTenantUser.getValue().get(0);
+        var idpTenant2 = mainRealmClient.createVerifiedUser().createTenant().toRepresentation();
+        idpAlias = createFirstLoginMembershipCreationIdp(Set.of(idpTenant1.getId(), idpTenant2.getId()));
+
+        // when
+        var nextPage = AccountPage.open()
+                .signIn()
+                .signInWith(idpAlias)
+                .fillCredentials(idpUser.getUserData().getEmail(), idpUser.getUserData().getPassword())
+                .signIn();
+
+        // then
+        assertThat(nextPage).isInstanceOf(SelectTenantPage.class);
+        assertThat(((SelectTenantPage) nextPage).availableOptions()).containsExactlyInAnyOrderElementsOf(
+                Stream.of(idpTenant1, idpTenant2).map(TenantRepresentation::getName).toList()
+        );
+    }
+
+    @Test
+    void shouldCreateMissingMembership_whenSignInUsingTenantIdpWithPostLoginTenantMembershipCreation() {
+        // given
+        var multiTenantUser = createMultiTenantUser();
+        var idpUser = idpRealmClient.createVerifiedUser(multiTenantUser.getKey());
+
+        var idpTenant1 = multiTenantUser.getValue().get(0);
+        var idpTenant2 = mainRealmClient.createVerifiedUser().createTenant().toRepresentation();
+        idpAlias = createPostLoginMembershipCreationIdp(Set.of(idpTenant1.getId(), idpTenant2.getId()));
+
+        // when
+        var nextPage = AccountPage.open()
+                .signIn()
+                .signInWith(idpAlias)
+                .fillCredentials(idpUser.getUserData().getEmail(), idpUser.getUserData().getPassword())
+                .signIn();
+
+        // then
+        assertThat(nextPage).isInstanceOf(SelectTenantPage.class);
+        assertThat(((SelectTenantPage) nextPage).availableOptions()).containsExactlyInAnyOrderElementsOf(
+                Stream.of(idpTenant1, idpTenant2).map(TenantRepresentation::getName).toList()
+        );
+    }
+
+    @Test
+    void shouldFail_whenSignInUsingTenantIdpWithoutTenantMembershipCreationAndWithoutAccessToAnyOfIdpTenants() {
+        // given
+        var multiTenantUser = createMultiTenantUser();
+        var idpUser = idpRealmClient.createVerifiedUser(multiTenantUser.getKey());
+
+        var idpTenant1 = mainRealmClient.createVerifiedUser().createTenant().toRepresentation();
+        var idpTenant2 = mainRealmClient.createVerifiedUser().createTenant().toRepresentation();
+        idpAlias = createIdpWithoutMembershipCreation(Set.of(idpTenant1.getId(), idpTenant2.getId()));
+
+        // when
+        var nextPage = AccountPage.open()
+                .signIn()
+                .signInWith(idpAlias)
+                .fillCredentials(idpUser.getUserData().getEmail(), idpUser.getUserData().getPassword())
+                .signIn();
+
+        // then
+        assertThat(nextPage).isInstanceOf(ErrorPage.class);
+    }
+
+    @Test
+    void shouldSeeTenantsCreatedByIdp_whenSignInUsingCredentials() {
+        // given
+        var multiTenantUser = createMultiTenantUser();
+        var idpUser = idpRealmClient.createVerifiedUser(multiTenantUser.getKey());
+
+        var idpTenant1 = mainRealmClient.createVerifiedUser().createTenant().toRepresentation();
+        var idpTenant2 = mainRealmClient.createVerifiedUser().createTenant().toRepresentation();
+        idpAlias = createFirstLoginMembershipCreationIdp(Set.of(idpTenant1.getId(), idpTenant2.getId()));
+
+        AccountPage.open()
+                .signIn()
+                .signInWith(idpAlias)
+                .fillCredentials(idpUser.getUserData().getEmail(), idpUser.getUserData().getPassword())
+                .signIn();
+
+        // when
+        var nextPage = AccountPage.open()
+                .signIn()
+                .fillCredentials(multiTenantUser.getKey().getEmail(), multiTenantUser.getKey().getPassword())
+                .signIn();
+
+        // then
+        assertThat(nextPage).isInstanceOf(SelectTenantPage.class);
+        assertThat(((SelectTenantPage) nextPage).availableOptions()).containsExactlyInAnyOrderElementsOf(
+                Stream.concat(multiTenantUser.getValue().stream(), Stream.of(idpTenant1, idpTenant2)).map(TenantRepresentation::getName).toList()
+        );
+    }
+
+    @Test
+    void shouldSeeOnlyIdpTenants_whenSignInUsingTenantIdp() {
+        // given
+        var multiTenantUser = createMultiTenantUser();
+        var idpUser = idpRealmClient.createVerifiedUser(multiTenantUser.getKey());
+
+        var idpTenant1 = multiTenantUser.getValue().get(1);
+        var idpTenant2 = multiTenantUser.getValue().get(2);
+        idpAlias = createFirstLoginMembershipCreationIdp(Set.of(idpTenant1.getId(), idpTenant2.getId()));
+
+        // when
+        var nextPage = AccountPage.open()
+                .signIn()
+                .signInWith(idpAlias)
+                .fillCredentials(idpUser.getUserData().getEmail(), idpUser.getUserData().getPassword())
+                .signIn();
+
+        // then
+        assertThat(nextPage).isInstanceOf(SelectTenantPage.class);
+        assertThat(((SelectTenantPage) nextPage).availableOptions()).containsExactlyInAnyOrder(idpTenant1.getName(), idpTenant2.getName());
+    }
+
+    @Test
+    void shouldAutomaticallySignIn_whenSignInUsingTenantIdpConfiguredWithOneTenant() {
+        // given
+        var multiTenantUser = createMultiTenantUser();
+        var idpUser = idpRealmClient.createVerifiedUser(multiTenantUser.getKey());
+
+        var idpTenant = multiTenantUser.getValue().get(0);
+        idpAlias = createFirstLoginMembershipCreationIdp(Set.of(idpTenant.getId()));
+
+        // when
+        var nextPage = AccountPage.open()
+                .signIn()
+                .signInWith(idpAlias)
+                .fillCredentials(idpUser.getUserData().getEmail(), idpUser.getUserData().getPassword())
+                .signIn();
+
+        // then
+        assertThat(nextPage).isInstanceOf(AccountPage.class);
+    }
+
+    private Map.Entry<UserData, List<TenantRepresentation>> createMultiTenantUser() {
+        var user = mainRealmClient.createVerifiedUser();
+        var tenants = new ArrayList<TenantRepresentation>();
+
+        for (int i = 0; i < 3; i++) {
+            var inviter = mainRealmClient.createVerifiedUser();
+            var tenantResource = inviter.createTenant();
+
+            var invitation = new TenantInvitationRepresentation();
+            invitation.setEmail(user.getUserData().getEmail());
+            try (var response = tenantResource.invitations().createInvitation(invitation)) {
+                assertThat(CreatedResponseUtil.getCreatedId(response)).isNotNull();
+            }
+            tenants.add(tenantResource.toRepresentation());
+        }
+
+        var nextPage = AccountPage.open()
+                .signIn()
+                .fillCredentials(user.getUserData().getEmail(), user.getUserData().getPassword())
+                .signIn();
+        ((ReviewInvitationsPage) nextPage).accept();
+        return new AbstractMap.SimpleImmutableEntry<>(user.getUserData(), tenants);
+    }
+
+    private String createFirstLoginMembershipCreationIdp(Set<String> tenantIds) {
+        return createIdentityProvider(FIRST_LOGIN_FLOW_WITH_MEMBERSHIP_CREATION, null, tenantIds);
+    }
+
+    private String createPostLoginMembershipCreationIdp(Set<String> tenantIds) {
+        return createIdentityProvider(FIRST_LOGIN_FLOW_WITHOUT_MEMBERSHIP_CREATION, POST_LOGIN_MEMBERSHIP_CREATION, tenantIds);
+    }
+
+    private String createIdpWithoutMembershipCreation(Set<String> tenantIds) {
+        return createIdentityProvider(FIRST_LOGIN_FLOW_WITHOUT_MEMBERSHIP_CREATION, null, tenantIds);
+    }
+
+    private String createIdentityProvider(String firstLoginFlow, @Nullable String postLoginFlow, Set<String> tenantIds) {
+        var idpAlias = FakerProvider.getFaker().internet().domainWord();
+
+        var provider = new IdentityProviderRepresentation();
+        provider.setProviderId("oidc");
+        provider.setAlias(idpAlias);
+        provider.setTrustEmail(true);
+        provider.setFirstBrokerLoginFlowAlias(firstLoginFlow);
+        if (postLoginFlow != null) {
+            provider.setPostBrokerLoginFlowAlias(postLoginFlow);
+        }
+
+        Map<String, String> config = new HashMap<>();
+        config.put("clientId", "test-client");
+        config.put("clientSecret", "jXqZRhLLkcuCE0EeRnSimblUiqmC8rMR");
+        config.put("authorizationUrl", IntegrationTestContextHolder.getContext().keycloakUrl() + "/realms/identity-provider/protocol/openid-connect/auth");
+        config.put("tokenUrl", "http://0.0.0.0:8080/realms/identity-provider/protocol/openid-connect/token");
+        config.put("jwksUrl", "http://0.0.0.0:8080/realms/identity-provider/protocol/openid-connect/certs");
+        config.put("useJwksUrl", "true");
+        config.put("multi-tenancy.tenants", String.join(",", tenantIds));
+        provider.setConfig(config);
+
+        try (var response = mainRealmClient.getRealmResource().identityProviders().create(provider)) {
+            return CreatedResponseUtil.getCreatedId(response);
+        }
+    }
+
+    private void deleteIdentityProvider(String alias) {
+        mainRealmClient.getRealmResource().identityProviders().get(alias).remove();
+    }
+}

--- a/src/test/java/dev/sultanov/keycloak/multitenancy/MailIntegrationTest.java
+++ b/src/test/java/dev/sultanov/keycloak/multitenancy/MailIntegrationTest.java
@@ -23,7 +23,7 @@ public class MailIntegrationTest extends BaseIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        keycloakAdminClient = KeycloakAdminCli.create();
+        keycloakAdminClient = KeycloakAdminCli.forMainRealm();
         mailhogClient = MailhogClient.create();
     }
 

--- a/src/test/java/dev/sultanov/keycloak/multitenancy/support/BaseIntegrationTest.java
+++ b/src/test/java/dev/sultanov/keycloak/multitenancy/support/BaseIntegrationTest.java
@@ -18,7 +18,7 @@ public class BaseIntegrationTest {
     private static final Integer MAILHOG_HTTP_PORT = 8025;
 
     private static final Network network = Network.newNetwork();
-    private static final KeycloakContainer keycloak = new KeycloakContainer("quay.io/keycloak/keycloak:22.0.3")
+    private static final KeycloakContainer keycloak = new KeycloakContainer("quay.io/keycloak/keycloak:22.0.5")
             .withRealmImportFiles("/realm-export.json", "/idp-realm-export.json")
             .withProviderClassesFrom("target/classes")
             .withNetwork(network)

--- a/src/test/java/dev/sultanov/keycloak/multitenancy/support/browser/ErrorPage.java
+++ b/src/test/java/dev/sultanov/keycloak/multitenancy/support/browser/ErrorPage.java
@@ -1,0 +1,10 @@
+package dev.sultanov.keycloak.multitenancy.support.browser;
+
+import com.microsoft.playwright.Page;
+
+public class ErrorPage extends AbstractPage {
+
+    ErrorPage(Page page) {
+        super(page);
+    }
+}

--- a/src/test/java/dev/sultanov/keycloak/multitenancy/support/browser/PageResolver.java
+++ b/src/test/java/dev/sultanov/keycloak/multitenancy/support/browser/PageResolver.java
@@ -17,6 +17,8 @@ class PageResolver {
             return new SelectTenantPage(page);
         } else if (page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName("Welcome to Keycloak account management")).isVisible()) {
             return new AccountPage(page);
+        } else if (page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName("We are sorry...")).isVisible()) {
+            return new ErrorPage(page);
         } else {
             throw new IllegalStateException("Unexpected page");
         }

--- a/src/test/java/dev/sultanov/keycloak/multitenancy/support/browser/SignInPage.java
+++ b/src/test/java/dev/sultanov/keycloak/multitenancy/support/browser/SignInPage.java
@@ -9,6 +9,12 @@ public class SignInPage extends AbstractPage {
         super(page);
     }
 
+    public SignInPage signInWith(String identityProvider) {
+        page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName(identityProvider)).click();
+        page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName(identityProvider)).isVisible();
+        return this;
+    }
+
     public SignInPage fillCredentials(String email, String password) {
         page.getByLabel("Email").fill(email);
         page.getByLabel("Password").fill(password);

--- a/src/test/java/dev/sultanov/keycloak/multitenancy/support/data/FakerProvider.java
+++ b/src/test/java/dev/sultanov/keycloak/multitenancy/support/data/FakerProvider.java
@@ -4,11 +4,11 @@ import com.github.javafaker.Faker;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
-class FakerProvider {
+public class FakerProvider {
 
     private static final Faker faker = new Faker();
 
-    static Faker getFaker() {
+    public static Faker getFaker() {
         return faker;
     }
 }

--- a/src/test/resources/idp-realm-export.json
+++ b/src/test/resources/idp-realm-export.json
@@ -1,0 +1,1805 @@
+{
+  "id" : "4d83d1d2-281c-40bd-a0e7-a1aba2a978fb",
+  "realm" : "identity-provider",
+  "notBefore" : 0,
+  "defaultSignatureAlgorithm" : "RS256",
+  "revokeRefreshToken" : false,
+  "refreshTokenMaxReuse" : 0,
+  "accessTokenLifespan" : 300,
+  "accessTokenLifespanForImplicitFlow" : 900,
+  "ssoSessionIdleTimeout" : 1800,
+  "ssoSessionMaxLifespan" : 36000,
+  "ssoSessionIdleTimeoutRememberMe" : 0,
+  "ssoSessionMaxLifespanRememberMe" : 0,
+  "offlineSessionIdleTimeout" : 2592000,
+  "offlineSessionMaxLifespanEnabled" : false,
+  "offlineSessionMaxLifespan" : 5184000,
+  "clientSessionIdleTimeout" : 0,
+  "clientSessionMaxLifespan" : 0,
+  "clientOfflineSessionIdleTimeout" : 0,
+  "clientOfflineSessionMaxLifespan" : 0,
+  "accessCodeLifespan" : 60,
+  "accessCodeLifespanUserAction" : 300,
+  "accessCodeLifespanLogin" : 1800,
+  "actionTokenGeneratedByAdminLifespan" : 43200,
+  "actionTokenGeneratedByUserLifespan" : 300,
+  "oauth2DeviceCodeLifespan" : 600,
+  "oauth2DevicePollingInterval" : 5,
+  "enabled" : true,
+  "sslRequired" : "external",
+  "registrationAllowed" : false,
+  "registrationEmailAsUsername" : true,
+  "rememberMe" : false,
+  "verifyEmail" : false,
+  "loginWithEmailAllowed" : true,
+  "duplicateEmailsAllowed" : false,
+  "resetPasswordAllowed" : false,
+  "editUsernameAllowed" : false,
+  "bruteForceProtected" : false,
+  "permanentLockout" : false,
+  "maxFailureWaitSeconds" : 900,
+  "minimumQuickLoginWaitSeconds" : 60,
+  "waitIncrementSeconds" : 60,
+  "quickLoginCheckMilliSeconds" : 1000,
+  "maxDeltaTimeSeconds" : 43200,
+  "failureFactor" : 30,
+  "roles" : {
+    "realm" : [ {
+      "id" : "e210c087-1c83-4b30-b38a-5e4808c18d6b",
+      "name" : "uma_authorization",
+      "description" : "${role_uma_authorization}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "4d83d1d2-281c-40bd-a0e7-a1aba2a978fb",
+      "attributes" : { }
+    }, {
+      "id" : "9786b161-f7ed-43d3-b525-af3a946dd380",
+      "name" : "offline_access",
+      "description" : "${role_offline-access}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "4d83d1d2-281c-40bd-a0e7-a1aba2a978fb",
+      "attributes" : { }
+    }, {
+      "id" : "eed2b545-4d22-449a-b471-bafcd61496df",
+      "name" : "default-roles-identity-provider",
+      "description" : "${role_default-roles}",
+      "composite" : true,
+      "composites" : {
+        "realm" : [ "offline_access", "uma_authorization" ],
+        "client" : {
+          "account" : [ "manage-account", "view-profile" ]
+        }
+      },
+      "clientRole" : false,
+      "containerId" : "4d83d1d2-281c-40bd-a0e7-a1aba2a978fb",
+      "attributes" : { }
+    } ],
+    "client" : {
+      "realm-management" : [ {
+        "id" : "7a50318b-1d85-4d70-bfef-112022930bd2",
+        "name" : "query-realms",
+        "description" : "${role_query-realms}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b180819d-0752-4035-b12f-dfb9d71866aa",
+        "attributes" : { }
+      }, {
+        "id" : "be6dc4a3-ae08-4de2-ba8f-78dcd0948adb",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b180819d-0752-4035-b12f-dfb9d71866aa",
+        "attributes" : { }
+      }, {
+        "id" : "4053f0f3-fea3-4045-93a6-cd9649d034c3",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b180819d-0752-4035-b12f-dfb9d71866aa",
+        "attributes" : { }
+      }, {
+        "id" : "7a401511-ec9e-456c-bb20-6c83240b0688",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b180819d-0752-4035-b12f-dfb9d71866aa",
+        "attributes" : { }
+      }, {
+        "id" : "91189c1b-ec3a-4f5b-b397-b2fa436956cc",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-clients" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "b180819d-0752-4035-b12f-dfb9d71866aa",
+        "attributes" : { }
+      }, {
+        "id" : "579da5d6-9999-476f-bcfe-be6d71e0c17f",
+        "name" : "view-authorization",
+        "description" : "${role_view-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b180819d-0752-4035-b12f-dfb9d71866aa",
+        "attributes" : { }
+      }, {
+        "id" : "b54d1e9d-97c9-4627-aff1-e4ff5c98e5b6",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b180819d-0752-4035-b12f-dfb9d71866aa",
+        "attributes" : { }
+      }, {
+        "id" : "3c034fed-40ea-4e1c-b3fe-cac0a63777f4",
+        "name" : "query-groups",
+        "description" : "${role_query-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b180819d-0752-4035-b12f-dfb9d71866aa",
+        "attributes" : { }
+      }, {
+        "id" : "7bb4d128-5211-4b0a-81e8-fde405e3f49b",
+        "name" : "realm-admin",
+        "description" : "${role_realm-admin}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-realms", "manage-authorization", "view-identity-providers", "create-client", "view-clients", "view-authorization", "manage-identity-providers", "query-groups", "query-clients", "manage-clients", "view-users", "query-users", "manage-realm", "manage-users", "view-realm", "impersonation", "manage-events", "view-events" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "b180819d-0752-4035-b12f-dfb9d71866aa",
+        "attributes" : { }
+      }, {
+        "id" : "a1739414-2fa0-48a8-93a9-bb1b484dc4e4",
+        "name" : "query-clients",
+        "description" : "${role_query-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b180819d-0752-4035-b12f-dfb9d71866aa",
+        "attributes" : { }
+      }, {
+        "id" : "826b6225-d5bd-4cfe-ab0a-f3ecfbbc754e",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b180819d-0752-4035-b12f-dfb9d71866aa",
+        "attributes" : { }
+      }, {
+        "id" : "c5967b55-4ea3-4ad3-819c-12cb8d96081c",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b180819d-0752-4035-b12f-dfb9d71866aa",
+        "attributes" : { }
+      }, {
+        "id" : "2b6dea39-2da0-4e3a-b25b-407ccf2428ad",
+        "name" : "query-users",
+        "description" : "${role_query-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b180819d-0752-4035-b12f-dfb9d71866aa",
+        "attributes" : { }
+      }, {
+        "id" : "124599c7-5d71-4d41-922a-7e34837ccf83",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-users", "query-groups" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "b180819d-0752-4035-b12f-dfb9d71866aa",
+        "attributes" : { }
+      }, {
+        "id" : "7b5f7841-9a3c-45ae-8656-7fb094c96abf",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b180819d-0752-4035-b12f-dfb9d71866aa",
+        "attributes" : { }
+      }, {
+        "id" : "4408bd6c-8662-461d-b561-ebcea41ca428",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b180819d-0752-4035-b12f-dfb9d71866aa",
+        "attributes" : { }
+      }, {
+        "id" : "411b5331-5994-4b21-9895-35583d081a39",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b180819d-0752-4035-b12f-dfb9d71866aa",
+        "attributes" : { }
+      }, {
+        "id" : "5a8e89e6-b47b-4726-84fa-61f8187e824c",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b180819d-0752-4035-b12f-dfb9d71866aa",
+        "attributes" : { }
+      }, {
+        "id" : "71208134-3610-4f67-bd45-ec07c23773ca",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "b180819d-0752-4035-b12f-dfb9d71866aa",
+        "attributes" : { }
+      } ],
+      "security-admin-console" : [ ],
+      "admin-cli" : [ ],
+      "test-client" : [ ],
+      "account-console" : [ ],
+      "broker" : [ {
+        "id" : "35c14126-5ade-42e7-be7e-133cf4ae3546",
+        "name" : "read-token",
+        "description" : "${role_read-token}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "fd282d4a-ddf2-456c-8ae9-c4d44934a14d",
+        "attributes" : { }
+      } ],
+      "account" : [ {
+        "id" : "3a4e7627-309f-4234-afc0-ea97afd35ac6",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "manage-account-links" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "95d014d3-61a6-4eec-ab9f-f06a600ecfbb",
+        "attributes" : { }
+      }, {
+        "id" : "16e70c83-d86b-4d95-8057-c434643ffd47",
+        "name" : "view-consent",
+        "description" : "${role_view-consent}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "95d014d3-61a6-4eec-ab9f-f06a600ecfbb",
+        "attributes" : { }
+      }, {
+        "id" : "3f57e91a-6dda-4529-80f8-93460c1aab06",
+        "name" : "delete-account",
+        "description" : "${role_delete-account}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "95d014d3-61a6-4eec-ab9f-f06a600ecfbb",
+        "attributes" : { }
+      }, {
+        "id" : "a178c31a-782a-4087-bdfc-ff9e4278b236",
+        "name" : "manage-consent",
+        "description" : "${role_manage-consent}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "view-consent" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "95d014d3-61a6-4eec-ab9f-f06a600ecfbb",
+        "attributes" : { }
+      }, {
+        "id" : "165e19e6-b887-4c4c-ae2e-7479f65c13f6",
+        "name" : "view-applications",
+        "description" : "${role_view-applications}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "95d014d3-61a6-4eec-ab9f-f06a600ecfbb",
+        "attributes" : { }
+      }, {
+        "id" : "2aaeda7a-8a2f-436f-8770-010704e348e8",
+        "name" : "manage-account-links",
+        "description" : "${role_manage-account-links}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "95d014d3-61a6-4eec-ab9f-f06a600ecfbb",
+        "attributes" : { }
+      }, {
+        "id" : "55c7d71e-9ebc-4b02-89d1-303acb9a7cd3",
+        "name" : "view-profile",
+        "description" : "${role_view-profile}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "95d014d3-61a6-4eec-ab9f-f06a600ecfbb",
+        "attributes" : { }
+      }, {
+        "id" : "967901dc-7ddf-4ffa-94ef-0875f6334f03",
+        "name" : "view-groups",
+        "description" : "${role_view-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "95d014d3-61a6-4eec-ab9f-f06a600ecfbb",
+        "attributes" : { }
+      } ]
+    }
+  },
+  "groups" : [ ],
+  "defaultRole" : {
+    "id" : "eed2b545-4d22-449a-b471-bafcd61496df",
+    "name" : "default-roles-identity-provider",
+    "description" : "${role_default-roles}",
+    "composite" : true,
+    "clientRole" : false,
+    "containerId" : "4d83d1d2-281c-40bd-a0e7-a1aba2a978fb"
+  },
+  "requiredCredentials" : [ "password" ],
+  "otpPolicyType" : "totp",
+  "otpPolicyAlgorithm" : "HmacSHA1",
+  "otpPolicyInitialCounter" : 0,
+  "otpPolicyDigits" : 6,
+  "otpPolicyLookAheadWindow" : 1,
+  "otpPolicyPeriod" : 30,
+  "otpPolicyCodeReusable" : false,
+  "otpSupportedApplications" : [ "totpAppMicrosoftAuthenticatorName", "totpAppFreeOTPName", "totpAppGoogleName" ],
+  "webAuthnPolicyRpEntityName" : "keycloak",
+  "webAuthnPolicySignatureAlgorithms" : [ "ES256" ],
+  "webAuthnPolicyRpId" : "",
+  "webAuthnPolicyAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyRequireResidentKey" : "not specified",
+  "webAuthnPolicyUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyCreateTimeout" : 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyAcceptableAaguids" : [ ],
+  "webAuthnPolicyPasswordlessRpEntityName" : "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms" : [ "ES256" ],
+  "webAuthnPolicyPasswordlessRpId" : "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey" : "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout" : 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
+  "users" : [{
+    "id": "65e18fcb-6663-425a-adc7-7c0a74ef93d4",
+    "createdTimestamp": 1610397005987,
+    "username": "service-account-admin-cli",
+    "enabled": true,
+    "totp": false,
+    "emailVerified": false,
+    "serviceAccountClientId": "admin-cli",
+    "disableableCredentialTypes": [],
+    "requiredActions": [],
+    "realmRoles": [
+      "uma_authorization",
+      "offline_access"
+    ],
+    "clientRoles": {
+      "realm-management": [
+        "manage-clients",
+        "manage-identity-providers",
+        "impersonation",
+        "create-client",
+        "query-users",
+        "query-realms",
+        "manage-events",
+        "query-clients",
+        "manage-users",
+        "manage-realm",
+        "manage-authorization",
+        "realm-admin"
+      ],
+      "account": [
+        "view-profile",
+        "manage-account"
+      ]
+    },
+    "notBefore": 0,
+    "groups": []
+  }],
+  "scopeMappings" : [ {
+    "clientScope" : "offline_access",
+    "roles" : [ "offline_access" ]
+  } ],
+  "clientScopeMappings" : {
+    "account" : [ {
+      "client" : "account-console",
+      "roles" : [ "manage-account", "view-groups" ]
+    } ]
+  },
+  "clients" : [ {
+    "id" : "95d014d3-61a6-4eec-ab9f-f06a600ecfbb",
+    "clientId" : "account",
+    "name" : "${client_account}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/identity-provider/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/identity-provider/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "c9f42502-6e97-44e4-978c-39a37ad2b5a9",
+    "clientId" : "account-console",
+    "name" : "${client_account-console}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/identity-provider/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/identity-provider/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "09c0d514-154b-4e87-9897-8757c0be75c1",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "b8eebc77-6fec-4f69-a40b-a81dbae7962c",
+    "clientId" : "admin-cli",
+    "name" : "${client_admin-cli}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret": "74c2b6f6-6109-4c29-b364-7b0943b5e724",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : true,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "fd282d4a-ddf2-456c-8ae9-c4d44934a14d",
+    "clientId" : "broker",
+    "name" : "${client_broker}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "b180819d-0752-4035-b12f-dfb9d71866aa",
+    "clientId" : "realm-management",
+    "name" : "${client_realm-management}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "2df4a7bf-1fbb-4f7d-99ee-d66310fefb86",
+    "clientId" : "security-admin-console",
+    "name" : "${client_security-admin-console}",
+    "rootUrl" : "${authAdminUrl}",
+    "baseUrl" : "/admin/identity-provider/console/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/admin/identity-provider/console/*" ],
+    "webOrigins" : [ "+" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "26af798c-7167-4761-ba99-af2f953fe03c",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "48fead99-87ee-41df-a76f-2a4f8fd6fe83",
+    "clientId" : "test-client",
+    "secret": "fa4ef7fc-4348-470a-bb9e-970a4e77b355",
+    "name" : "",
+    "description" : "",
+    "rootUrl" : "",
+    "adminUrl" : "",
+    "baseUrl" : "",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : true,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "oidc.ciba.grant.enabled" : "false",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "backchannel.logout.session.required" : "true",
+      "backchannel.logout.revoke.offline.tokens" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  } ],
+  "clientScopes" : [ {
+    "id" : "039a8f8e-dd00-4430-b28f-56c64d20d541",
+    "name" : "role_list",
+    "description" : "SAML role list",
+    "protocol" : "saml",
+    "attributes" : {
+      "consent.screen.text" : "${samlRoleListScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "0982a4fe-192e-4003-b6bc-75026b24b490",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "b5ac1d71-00c7-4ee0-9f87-f8d5ff213ac7",
+    "name" : "offline_access",
+    "description" : "OpenID Connect built-in scope: offline_access",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "consent.screen.text" : "${offlineAccessScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    }
+  }, {
+    "id" : "a06a1c07-2a7a-45ba-a82b-282e36eaac2b",
+    "name" : "phone",
+    "description" : "OpenID Connect built-in scope: phone",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${phoneScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "b85d6d29-9bed-43a3-a8b4-9bfa4b76b515",
+      "name" : "phone number verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumberVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number_verified",
+        "jsonType.label" : "boolean"
+      }
+    }, {
+      "id" : "983fd6d6-1681-4aea-bdec-88ff13112ff2",
+      "name" : "phone number",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumber",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "6326fd43-2fc2-457b-9e55-1be638d1af85",
+    "name" : "microprofile-jwt",
+    "description" : "Microprofile - JWT built-in scope",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "9b5dc7d2-510d-4532-8962-28d39d7881c9",
+      "name" : "groups",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "multivalued" : "true",
+        "user.attribute" : "foo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "groups",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "ecc9d3e7-9312-4ca0-8c06-35fc1ff22964",
+      "name" : "upn",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "upn",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "0cc3e859-c707-4c62-9af2-b82519ef3fb6",
+    "name" : "address",
+    "description" : "OpenID Connect built-in scope: address",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${addressScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "8527adfa-a146-4204-b409-5be08af8d4d6",
+      "name" : "address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-address-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute.formatted" : "formatted",
+        "user.attribute.country" : "country",
+        "user.attribute.postal_code" : "postal_code",
+        "userinfo.token.claim" : "true",
+        "user.attribute.street" : "street",
+        "id.token.claim" : "true",
+        "user.attribute.region" : "region",
+        "access.token.claim" : "true",
+        "user.attribute.locality" : "locality"
+      }
+    } ]
+  }, {
+    "id" : "aff6c314-ee1c-44b5-8b45-caf76d6977cb",
+    "name" : "email",
+    "description" : "OpenID Connect built-in scope: email",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${emailScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "d24a5f66-e878-4ced-8dac-d7a37830ec5b",
+      "name" : "email verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "emailVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email_verified",
+        "jsonType.label" : "boolean"
+      }
+    }, {
+      "id" : "bee6d591-f245-4f3e-a6b7-0f964e5c556b",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "275dffd7-4c10-421c-8a9b-e6c587b6d297",
+    "name" : "acr",
+    "description" : "OpenID Connect scope for add acr (authentication context class reference) to the token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "3aeb621b-73d9-45a1-8405-ce05f002009f",
+      "name" : "acr loa level",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-acr-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "1d987553-ca42-4808-982d-3cb4a323f030",
+    "name" : "roles",
+    "description" : "OpenID Connect scope for add user roles to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${rolesScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "6f1ce061-010d-424e-9fbc-f772a9ec3483",
+      "name" : "client roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-client-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "resource_access.${client_id}.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "20fadeaa-d3df-4f9c-ad45-37b6a220c4b7",
+      "name" : "realm roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "realm_access.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "79f7851d-9ad8-40c1-8174-51831c09469b",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ]
+  }, {
+    "id" : "8b8bae62-2bd2-4302-878f-70bd68cb5b82",
+    "name" : "web-origins",
+    "description" : "OpenID Connect scope for add allowed web origins to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false",
+      "consent.screen.text" : ""
+    },
+    "protocolMappers" : [ {
+      "id" : "81673146-189c-4f96-96f5-c350e3dbfff5",
+      "name" : "allowed web origins",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-allowed-origins-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ]
+  }, {
+    "id" : "c1b73d65-6ad6-4ddf-86a7-ffb38bd025c3",
+    "name" : "profile",
+    "description" : "OpenID Connect built-in scope: profile",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${profileScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "27bd44dd-03a7-408d-9d27-1c6800932f15",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "2d3dfc82-c3f7-4827-a416-7224f4937943",
+      "name" : "website",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "website",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "website",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "83e52512-5d55-465b-b2da-b3667d4bf7b2",
+      "name" : "gender",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "gender",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "gender",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "b16790cd-07f3-40d8-9604-2c24a467c33c",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c656c259-df21-47b8-bc38-014cf2a6fe40",
+      "name" : "birthdate",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "birthdate",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "birthdate",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "ea7e3240-7ffe-4795-9626-7e770e4890c0",
+      "name" : "middle name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "middleName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "middle_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "11d31332-20bb-4447-8a73-1977d0a35aab",
+      "name" : "zoneinfo",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "zoneinfo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "zoneinfo",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "bb04d760-3663-47fd-91e0-49c7dde99971",
+      "name" : "updated at",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "updatedAt",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "updated_at",
+        "jsonType.label" : "long"
+      }
+    }, {
+      "id" : "68de2d2f-13de-4ba0-a763-cc4a2bba933f",
+      "name" : "picture",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "picture",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "picture",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "0f2d6603-a579-4b05-acca-613bb49db29b",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    }, {
+      "id" : "bcf81eaa-13f2-4e3e-83e4-aaa4d3bf83ff",
+      "name" : "nickname",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "nickname",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "nickname",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "8ce4897c-a2e2-43d1-8cc7-8be8c819a1c6",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "383dbe28-83bf-4726-9b64-128455e473bf",
+      "name" : "profile",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "profile",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "profile",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "84bdd790-2803-4569-be45-a8361f9f4404",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    } ]
+  } ],
+  "defaultDefaultClientScopes" : [ "role_list", "profile", "email", "roles", "web-origins", "acr" ],
+  "defaultOptionalClientScopes" : [ "offline_access", "address", "phone", "microprofile-jwt" ],
+  "browserSecurityHeaders" : {
+    "contentSecurityPolicyReportOnly" : "",
+    "xContentTypeOptions" : "nosniff",
+    "referrerPolicy" : "no-referrer",
+    "xRobotsTag" : "none",
+    "xFrameOptions" : "SAMEORIGIN",
+    "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection" : "1; mode=block",
+    "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer" : { },
+  "eventsEnabled" : false,
+  "eventsListeners" : [ "jboss-logging" ],
+  "enabledEventTypes" : [ ],
+  "adminEventsEnabled" : false,
+  "adminEventsDetailsEnabled" : false,
+  "identityProviders" : [ ],
+  "identityProviderMappers" : [ ],
+  "components" : {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
+      "id" : "29dc56dd-7430-4785-b23e-cb81e2f5df86",
+      "name" : "Full Scope Disabled",
+      "providerId" : "scope",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "02a8f7a4-d699-49f1-8bdb-8af967a69da6",
+      "name" : "Consent Required",
+      "providerId" : "consent-required",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "32330af1-8689-43ef-88d1-175912e55d38",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "oidc-address-mapper", "saml-user-property-mapper", "saml-role-list-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-usermodel-property-mapper", "saml-user-attribute-mapper", "oidc-full-name-mapper", "oidc-usermodel-attribute-mapper" ]
+      }
+    }, {
+      "id" : "3ace82a5-d1e5-45e4-a273-57f43598e206",
+      "name" : "Max Clients Limit",
+      "providerId" : "max-clients",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "max-clients" : [ "200" ]
+      }
+    }, {
+      "id" : "a49d32fd-8497-4e41-a12b-983b227d3364",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "oidc-address-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-usermodel-attribute-mapper", "oidc-usermodel-property-mapper", "saml-user-attribute-mapper", "saml-user-property-mapper", "oidc-full-name-mapper", "saml-role-list-mapper" ]
+      }
+    }, {
+      "id" : "3f3e671b-65a6-47e5-a905-3f2dc2aba1e1",
+      "name" : "Trusted Hosts",
+      "providerId" : "trusted-hosts",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "host-sending-registration-request-must-match" : [ "true" ],
+        "client-uris-must-match" : [ "true" ]
+      }
+    }, {
+      "id" : "e50973c5-b530-499e-ba06-a0fb7586c236",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "881896d6-3a99-4d27-9dfb-d416a16fb98b",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    } ],
+    "org.keycloak.keys.KeyProvider" : [ {
+      "id" : "b37a35f4-11c6-4215-a94d-ac53645b237b",
+      "name" : "rsa-enc-generated",
+      "providerId" : "rsa-enc-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEowIBAAKCAQEAk5NZXCkSQJWCUdpOBpUWak1usH4lBgp9rrepazzpiut+dUzIW7y03CIAbt/Oed22/fb0mKueqlB0hpv08mivO8r1kf2N1swZlY3fUzULCvYD2PMnKnn1wyA4zPS32JUaw1/XnO5n0J0o43Z48pEqhpa+WlKwm3ZMRzq6qvija5yg/xlrgise1ma3E379zzc7rKPZkVawkr6wLZMrftTf7YKW4jP8LNrO3bKR8DY878mDBg1JNWx+bhyzI94IxTacTcmX822VezPnA3jNnFer6xwTKP1jnE7acelV3PtawCa+TRZXemnIVglgsjFW5O2zoBz+uSd4nyTmpsGd2X+L7wIDAQABAoIBACG6MVgQwu0jvk76t45lkGPnIn8PtWJ2D1dY/k1V9IIdZB9m1vuwWx1cYAD3AXd0ppfQUwJ5Zp/CF3+UMR0ds77Umd8ttbb7mnVFoV6g5s8wfpycpbzddr+Lo6+j1kiXezBfvSVOj0dsQ6YIs4esia2M0iBOebJuDOzSjUr53E+BeanDYwWKAx3qCrM9Q1aDdznABvVpHXwc1mngWueD8tPhJzyRVin8/ZD5hNPJhdwyhDhVp+/R4LHM7JdawDwo/LWN7F4Eqk1X3qFW1LK3LBriCRwh1aDkXCHKViq4sYxly5BOur5VnA6jLce7yaFDVYSQ22khMYCpjxvVeHUIXzECgYEAwuuRSGHCEWgQdXa00iMP+8NgAUyurhCbNsclvNO1afj/1CSCE8YFfR0upecABXr499TOh5ZqhWxu4dwr4DsXNsj6lRK7vQMG6fu+Sxf6wmIx2BnQpBy+CsEPN/DwG3GPEy7EjdyH1Vwve2HJE4OxGEmXsJ6yVxTl1zA1u8UqWn0CgYEAwdHQLruwLVNP6/7Cmy7J7ujm2oiuHQOEelhUq40p4X/PCgSvKR9evpfABRq1LhhGBnGDHl6tdlzjEZMMK6J5fURcqzt35i1G3aEM9bBb+ashVaaxqE86/kfDlziZpqi+1+WjZlRqkuHMjpv1yyw8Y2pf+iYjUbT94F5eagS7H9sCgYBJLiH8d99ho51STH/0yP8uOZrowf5vEYMEnN4ZN67Lm5WI8y/29oiHAZbK6KBEbnfcrAPiOeHCOASlPYEnjWfYxLn3j/H2M5W78SzvipA1vKIUDRUdGEFtTjBFg2rSEt9xh0R6Mkq5GwQkoYDZl768bJzLzbkNIqZsFQiHd63ADQKBgQC84voNIVLfyUqhRmVnkOCxGX8pyHxOwEfSZ9UUXv1KyyD9tXTzEaRnAELddprNslBEJUnQRhqsuHd+gB0jRTM69m2NXuZJhySCB1s28UmhdrqE23BWA+kNOOkPrdRoTBm5FA37Qxedz7pn3Oxctd6gUGH6ykIvdcDZcX53ueaXcwKBgEjQXA1m+0wL1kKT62Srt13zTqte+16FhtuSFF+kTPSewOHDk22pcrapHv5anjB1YLXZ037t2h0OGz+klkCY1RtgGd4G3SdymvZR1h9tD36NOxOomzRZVWW1UsYbLjVvddvMd0ysUqxN/INBGuM/+w9MBoAeqM3PsMvd8WyCmHlY" ],
+        "keyUse" : [ "ENC" ],
+        "certificate" : [ "MIICsTCCAZkCBgGLYitX6jANBgkqhkiG9w0BAQsFADAcMRowGAYDVQQDDBFpZGVudGl0eS1wcm92aWRlcjAeFw0yMzEwMjQxNDQ5NDlaFw0zMzEwMjQxNDUxMjlaMBwxGjAYBgNVBAMMEWlkZW50aXR5LXByb3ZpZGVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAk5NZXCkSQJWCUdpOBpUWak1usH4lBgp9rrepazzpiut+dUzIW7y03CIAbt/Oed22/fb0mKueqlB0hpv08mivO8r1kf2N1swZlY3fUzULCvYD2PMnKnn1wyA4zPS32JUaw1/XnO5n0J0o43Z48pEqhpa+WlKwm3ZMRzq6qvija5yg/xlrgise1ma3E379zzc7rKPZkVawkr6wLZMrftTf7YKW4jP8LNrO3bKR8DY878mDBg1JNWx+bhyzI94IxTacTcmX822VezPnA3jNnFer6xwTKP1jnE7acelV3PtawCa+TRZXemnIVglgsjFW5O2zoBz+uSd4nyTmpsGd2X+L7wIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQAs6uAn2d3ZpX2gg+FoGBX0G7Gklk2P3y7VrFGlkLGkv0tDnJqZMsRXv1SGUKTjnDB4bn6cBNYkxevIle4RAkR12LkBfLVAx1prCU1g4AgSgeeQXZjFBWpSNl3LeUog+tEm9vYfOX2XfiBCoa/jqI7O6Kupu1lM1hRiaCwYu2/HHEb+spO0x11m5uTdsIBGae5lkBGsgXM9XSwxLXEYugMx7zgASfUm5b4Y4XpDWPxLB8JO9AtWbuLNnzdC+Vw7vQ1DrU/I2CkHGnn0aOJDi79dsw5kwkr+P1K520A7UoxsDG9BnOzqChetY1qbIbYDml5jUAERR11e9S+WLIGFfwsh" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "RSA-OAEP" ]
+      }
+    }, {
+      "id" : "cb8e4f3d-a302-479e-bad1-4e6a31893bb8",
+      "name" : "hmac-generated",
+      "providerId" : "hmac-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "c965f43d-357d-4ab7-a5f7-11c748be467f" ],
+        "secret" : [ "Ds6BarEwhHGCNF4sV4Fs-ANGPQQ26W1eydHE6AtgGYzw76-naflvI9sgf0mh0diVT8dSir6Qq7iV-yT_sEEA_A" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "HS256" ]
+      }
+    }, {
+      "id" : "70237b6e-db91-4cae-863a-56766a867413",
+      "name" : "rsa-generated",
+      "providerId" : "rsa-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEpQIBAAKCAQEAy540vj5+KdHMTFSdkM6V7SMJDGS5nnJshNIiQgXQxPvYcWxXaGTz5F0xthtNhnN9Pyy5R+QuqBFcm4190zk7h+Uznm7Z5s9T7pdcio3kOOUjtwVzCrAstzPzoHzCuIEvo67qk3IP/GROqF3plBL60Jk3c4jCdsUFY1515nWqPFWbP2bNsS/fI3+/ph/K+miueivPTQyB2jDLnIyYFoLitfLPW0EaI6w3G5XSHy866IyywkCl9ATjeB80JoQaST7JNGm/09xuH5SfRsl8p22Q+PykCHW7mDne6DqICPHlt81H//04f0Jqk6zzm79hcqws/EAxH4lfhLRJpbNHXX0AaQIDAQABAoIBACwcRlXOaPt7STRiAk5sCpu4Qs4OBg42wJ6XfTdrVhpOasnLjDX/5LwcmlfWm1lcrI3ijPLvklHzjOnf4ZnAJM7gTunsHsV7NbYS0UfszDutHCsagZ0XpGA933HthSt+RQlDK+ssQx1Mx6N+0Mq0v+QvxQ0A3Avpy6yGuqjl5a6zA7Zh4TDMd3KK/D97rGVDnNg7mJKlLjzbLl3NyKSoPiTo65bAq4G6i/LIAwu9N7R+ldr5vXRYKW7eRSR2uYBPXaHVmvqj+aFMbWqQm5l+gM+9FmwsuH5ttEmaT0Ptfyixna3Y8kIAuNaHZSU515b0v5h6t//ZYA6ycBmLRjeGIQ8CgYEA9zWY7LEp4ziYq254egsxgF1Ya0GYK1LsnJz9eD2afwOY9BICFXSykT0TmAxUhlBI/VIcqUkq6ZcMwiuODeYjcqECRS1bpuzLaIC48RaYDEE7+lEStmVUsU8W1QgbDYRqNM5mfUA1vJkZsiciHdW0A7qMmCdPqQZoo+aoigjgBKcCgYEA0tvJXFlrgU3lXFoz+xjsAWgbkJPri5pc7XawgFoj9aYNbkZGfNQCtulyB1++hgHJpfUAuAwuvIbpYz6XD1WqtNlcjjNyJAu88uLFJOcH8lNyMAk/G5vsmmceZoBDE3v+iNSytIWB4t6F9FVSNkO8NL0OrJrDIaSvLyLrej+gpG8CgYEAtp/KxHiw6CJkbqjiqc5hGGJdMoc3wjG1iJFVkyF3ZAOlWBGBppYaYL9NHVNmkf73nOSvNcROxlgHXd5NSClO4Jzfj3lNrwhZ0G7fsYMuekcq5uZDu6kqIv65cFFXounCiBY+kqL/z78Ow5SzWHUKUoLa4ICSEd0hKov40Fh0HhsCgYEAhFJm56w52bgvcigtLKs0F6HkgnNBQqdJH7/2/WUT4eklzokNXPKTDYQsCdKctm3SxHGe1ODYR3kGZ0B0/auN59XrzlUckOBI38dNXl4ZT4nsQ5bZ4pKUBUUm/74H2edbETUhPEX3/44TVARjBii1qAboeYrZX3iAcz0ftuTNA8MCgYEAvGTtCnW+QFylKV2kx1aK1GidvjpouDAkW6LFR9UXXjOKthyJyUeBloNINsUXvxvI1Km2yEtVqRZaupmp/CUYN/NgtCVc/QVUmCxqo7Eurja2N/Lmbiidavdwfy8oDD0MSibikBbWkDQKiP11n0H3jz/p7CN0VjgLxE4mfKdtcmo=" ],
+        "keyUse" : [ "SIG" ],
+        "certificate" : [ "MIICsTCCAZkCBgGLYitW/jANBgkqhkiG9w0BAQsFADAcMRowGAYDVQQDDBFpZGVudGl0eS1wcm92aWRlcjAeFw0yMzEwMjQxNDQ5NDlaFw0zMzEwMjQxNDUxMjlaMBwxGjAYBgNVBAMMEWlkZW50aXR5LXByb3ZpZGVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAy540vj5+KdHMTFSdkM6V7SMJDGS5nnJshNIiQgXQxPvYcWxXaGTz5F0xthtNhnN9Pyy5R+QuqBFcm4190zk7h+Uznm7Z5s9T7pdcio3kOOUjtwVzCrAstzPzoHzCuIEvo67qk3IP/GROqF3plBL60Jk3c4jCdsUFY1515nWqPFWbP2bNsS/fI3+/ph/K+miueivPTQyB2jDLnIyYFoLitfLPW0EaI6w3G5XSHy866IyywkCl9ATjeB80JoQaST7JNGm/09xuH5SfRsl8p22Q+PykCHW7mDne6DqICPHlt81H//04f0Jqk6zzm79hcqws/EAxH4lfhLRJpbNHXX0AaQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQCDwqK9oQ/Vr8sAqg//64RUwjErqY9K5P5LKGR+uOwVjtTGVVPgyGosWC+G9iZypGQe5+0t+UaVsQNdLqVxqdGVI1Lf2VDVPULMH80ID52O1eOvcT5up8nSaqxw/OWh1RyBPGQbnVWXDu9DvnQTbeEIQIvlH8CcuHbA0HHsDym4VEvev/e2C6foRFLtKuG65wwBkMNziNNuYpEfTS6hZCyVB61tvNb3HO9xW5ut8QwrVDWDnKaPeyeiDv1zeXT5GFaTUtvx9B75i0GDkBr37/yuOj2DzLwg2ZYJ8P2ze0QPTC00fZVKMJrZqQV9VG90c9aw71FFa3Z8+V9Hr9meYGuF" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "6853fb08-d6c4-41d6-81c2-92308e5161ac",
+      "name" : "aes-generated",
+      "providerId" : "aes-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "4390f224-f47b-40c6-800b-eb714d3e9f6f" ],
+        "secret" : [ "-e4cozrnxQLvUHnBvKwNWA" ],
+        "priority" : [ "100" ]
+      }
+    } ]
+  },
+  "internationalizationEnabled" : false,
+  "supportedLocales" : [ ],
+  "authenticationFlows" : [ {
+    "id" : "8f730edf-77fc-4ff7-a0c0-60c2b1bfa9f1",
+    "alias" : "Account verification options",
+    "description" : "Method with which to verity the existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-email-verification",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Verify Existing Account by Re-authentication",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "b50e745b-2f5f-4896-84c8-3fdd1977c289",
+    "alias" : "Browser - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "ce547476-a9c4-4b33-a798-0b0794ed1b47",
+    "alias" : "Direct Grant - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "3d9e02c2-b465-4171-ab04-f61d7f38c5c0",
+    "alias" : "First broker login - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "381b836c-96b6-4ea4-b1b9-88f6fa971a8c",
+    "alias" : "Handle Existing Account",
+    "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-confirm-link",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Account verification options",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "f6e35ee3-2457-449e-bcc9-086e8c513b93",
+    "alias" : "Reset - Conditional OTP",
+    "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "8b4ced19-71f9-4b68-8f2d-5c4a53a9476c",
+    "alias" : "User creation or linking",
+    "description" : "Flow for the existing/non-existing user alternatives",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "create unique user config",
+      "authenticator" : "idp-create-user-if-unique",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Handle Existing Account",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "001b6219-b7ba-41ae-bab0-0a404fbf66ee",
+    "alias" : "Verify Existing Account by Re-authentication",
+    "description" : "Reauthentication of existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "First broker login - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "cb87c02d-8bfc-4d76-ac71-5b1eebf03724",
+    "alias" : "browser",
+    "description" : "browser based authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-cookie",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "identity-provider-redirector",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 25,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "forms",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "8765e5e5-e89d-4551-9577-0ac4aa67a521",
+    "alias" : "clients",
+    "description" : "Base authentication for clients",
+    "providerId" : "client-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "client-secret",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-secret-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-x509",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "0540ea41-ab3e-41f8-a4ab-aad0e315e943",
+    "alias" : "direct grant",
+    "description" : "OpenID Connect Resource Owner Grant",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "direct-grant-validate-username",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Direct Grant - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "cca6da79-62dd-4d3a-a218-45670d020096",
+    "alias" : "docker auth",
+    "description" : "Used by Docker clients to authenticate against the IDP",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "docker-http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "06f998ea-ebdf-4cba-b9b8-f8a7fffa3d13",
+    "alias" : "first broker login",
+    "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "review profile config",
+      "authenticator" : "idp-review-profile",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "User creation or linking",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "128a2cb0-931b-4aad-be7b-55477654bf9a",
+    "alias" : "forms",
+    "description" : "Username, password, otp and other auth forms.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Browser - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "00d0ea98-a8cd-4930-8c34-fb04db73367b",
+    "alias" : "registration",
+    "description" : "registration flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-page-form",
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : true,
+      "flowAlias" : "registration form",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "b3513d93-82f8-4397-9246-da3bf1b13d31",
+    "alias" : "registration form",
+    "description" : "registration form",
+    "providerId" : "form-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-user-creation",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-profile-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-password-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 50,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-recaptcha-action",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 60,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "ec3643df-c345-4264-8daf-e5c3503a8341",
+    "alias" : "reset credentials",
+    "description" : "Reset credentials for a user if they forgot their password or something",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "reset-credentials-choose-user",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-credential-email",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 40,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Reset - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "ddde16ad-e3b6-42fa-9762-4762bd8ba6d6",
+    "alias" : "saml ecp",
+    "description" : "SAML ECP Profile Authentication Flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  } ],
+  "authenticatorConfig" : [ {
+    "id" : "4a1fc29e-8d40-47ec-939e-e1c2fdf70214",
+    "alias" : "create unique user config",
+    "config" : {
+      "require.password.update.after.registration" : "false"
+    }
+  }, {
+    "id" : "5b5e42ad-7628-4a1b-b67b-68c8dbba5f9e",
+    "alias" : "review profile config",
+    "config" : {
+      "update.profile.on.first.login" : "missing"
+    }
+  } ],
+  "requiredActions" : [ {
+    "alias" : "CONFIGURE_TOTP",
+    "name" : "Configure OTP",
+    "providerId" : "CONFIGURE_TOTP",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 10,
+    "config" : { }
+  }, {
+    "alias" : "TERMS_AND_CONDITIONS",
+    "name" : "Terms and Conditions",
+    "providerId" : "TERMS_AND_CONDITIONS",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 20,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PASSWORD",
+    "name" : "Update Password",
+    "providerId" : "UPDATE_PASSWORD",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 30,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PROFILE",
+    "name" : "Update Profile",
+    "providerId" : "UPDATE_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 40,
+    "config" : { }
+  }, {
+    "alias" : "VERIFY_EMAIL",
+    "name" : "Verify Email",
+    "providerId" : "VERIFY_EMAIL",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 50,
+    "config" : { }
+  }, {
+    "alias" : "delete_account",
+    "name" : "Delete Account",
+    "providerId" : "delete_account",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 60,
+    "config" : { }
+  }, {
+    "alias" : "webauthn-register",
+    "name" : "Webauthn Register",
+    "providerId" : "webauthn-register",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 70,
+    "config" : { }
+  }, {
+    "alias" : "webauthn-register-passwordless",
+    "name" : "Webauthn Register Passwordless",
+    "providerId" : "webauthn-register-passwordless",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 80,
+    "config" : { }
+  }, {
+    "alias" : "update_user_locale",
+    "name" : "Update User Locale",
+    "providerId" : "update_user_locale",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 1000,
+    "config" : { }
+  } ],
+  "browserFlow" : "browser",
+  "registrationFlow" : "registration",
+  "directGrantFlow" : "direct grant",
+  "resetCredentialsFlow" : "reset credentials",
+  "clientAuthenticationFlow" : "clients",
+  "dockerAuthenticationFlow" : "docker auth",
+  "attributes" : {
+    "cibaBackchannelTokenDeliveryMode" : "poll",
+    "cibaExpiresIn" : "120",
+    "cibaAuthRequestedUserHint" : "login_hint",
+    "oauth2DeviceCodeLifespan" : "600",
+    "oauth2DevicePollingInterval" : "5",
+    "parRequestUriLifespan" : "60",
+    "cibaInterval" : "5",
+    "realmReusableOtpCode" : "false"
+  },
+  "keycloakVersion" : "22.0.5",
+  "userManagedAccessAllowed" : false,
+  "clientProfiles" : {
+    "profiles" : [ ]
+  },
+  "clientPolicies" : {
+    "policies" : [ ]
+  }
+}

--- a/src/test/resources/realm-export.json
+++ b/src/test/resources/realm-export.json
@@ -1621,6 +1621,122 @@
       ]
     },
     {
+      "id": "f44e27df-6540-4b10-883f-8564818891e0",
+      "alias": "first broker login with tenant membership creation",
+      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "first broker login with tenant membership creation User creation or linking",
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "idp-tenant-memberships",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 21,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "fb8ccf8e-98ed-4a58-8f07-d7ef4f2e973e",
+      "alias": "first broker login with tenant membership creation User creation or linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "first broker login with tenant membership creation create unique user config",
+          "authenticator": "idp-create-user-if-unique",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "idp-auto-link",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 21,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "ab04cd6b-deab-405b-b149-424ee92a695c",
+      "alias": "first broker login without tenant membership creation",
+      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "first broker login without tenant membership creation User creation or linking",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "f72e8160-f4e8-4d9e-8d97-8099e10ebda5",
+      "alias": "first broker login without tenant membership creation User creation or linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "first broker login without tenant membership creation create unique user config",
+          "authenticator": "idp-create-user-if-unique",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "idp-auto-link",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 21,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "9aa92661-bcea-4f75-b5be-dc29131353db",
+      "alias": "create tenant memberships only",
+      "description": "",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-tenant-memberships",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 0,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
       "id": "b3e15a95-4498-4344-8255-92af57b22242",
       "alias": "forms",
       "description": "Username, password, otp and other auth forms.",
@@ -1807,6 +1923,20 @@
       "alias": "review profile config",
       "config": {
         "update.profile.on.first.login": "missing"
+      }
+    },
+    {
+      "id": "4015a14f-21bb-4132-9778-b60adebe4bb5",
+      "alias": "first broker login with tenant membership creation create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
+      }
+    },
+    {
+      "id": "5cf82057-28e6-418d-8862-f4b7c0ab456d",
+      "alias": "first broker login without tenant membership creation create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
       }
     }
   ],


### PR DESCRIPTION
This PR enhances the extension's functionality by integrating it with Identity Providers (IDPs) , enabling a smooth user onboarding and authentication process with external IDPs across different tenants, by introducing the concept of tenant-specific IDPs. 

**1. Tenant-Specific IDP Configuration:**
- To enable tenant-specific configuration for IDPs, tenants' IDs should be added to the `multi-tenancy.tenants` configuration attribute of the IDP as __comma separated list__.  This can be accomplished using the standard [Keycloak REST API](https://www.keycloak.org/docs-api/22.0.5/rest-api/index.html#_identity_providers).
- With tenant-specific IDP configuration, IDP restricts access to only tenants listed in the configuration. If a user signing in with IDP isn't a member of any of these tenants and automatic membership creation isn't configured, an error will be generated.

**2. Automatic Tenant Membership Creation:**
- By including the `create tenant membership` authenticator in the IDP's `first login flow`, users can be automatically added as members of all the configured tenants during their initial login. 
- Alternatively, this authenticator can be added into `post login flow` allowing memberships to be created even for tenants added to the IDP after the user has already been onboarded.

**3. Public IDP Configuration:**
- IDPs lacking the `multi-tenancy.tenants` configuration attribute are considered public.
- These public IDPs grant access to any tenants for users who are members of those tenants.
- This ensures compatibility with existing setups, as it doesn't disrupt the way things were previously configured.