### PR TITLE
docs: correct new default API path (Keycloak 17+)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -552,6 +552,6 @@
     "version" : "26.0.2"
   },
   "servers" : [ {
-    "url" : "{{keycloakUrl}}/auth/realms/{{realmName}}"
+    "url" : "{{keycloakUrl}}/realms/{{realmName}}"
   } ]
 }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -381,4 +381,4 @@ info:
   title: Keycloak Multi-Tenancy
   version: 26.0.2
 servers:
-- url: "{{keycloakUrl}}/auth/realms/{{realmName}}"
+- url: "{{keycloakUrl}}/realms/{{realmName}}"


### PR DESCRIPTION
While trying to access the keycloak-multi-tenancy API endpoints, I encountered the error: "Unable to find matching target resource method."

After investigating, I discovered that since Keycloak 17, the default API URL path has changed from `{root}/auth/realms/...` to `{root}/realms/....`. See https://www.keycloak.org/migration/migrating-to-quarkus

This PR updates the OpenAPI specification files to reflect the new default path, ensuring that new users of this extension won't encounter the same issue.