### PR TITLE
Fix PUT behavior for tenant attributes field

### DIFF
--- a/src/main/java/dev/sultanov/keycloak/multitenancy/resource/representation/TenantRepresentation.java
+++ b/src/main/java/dev/sultanov/keycloak/multitenancy/resource/representation/TenantRepresentation.java
@@ -3,7 +3,6 @@ package dev.sultanov.keycloak.multitenancy.resource.representation;
 import lombok.Data;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import java.util.Map;
-import java.util.HashMap;
 import java.util.List;
 
 @Schema
@@ -20,5 +19,5 @@ public class TenantRepresentation {
     private String realm;
 
     @Schema(description = "Attributes of the tenant")
-    private Map<String, List<String>> attributes = new HashMap<>();
+    private Map<String, List<String>> attributes;
 }

--- a/src/test/java/dev/sultanov/keycloak/multitenancy/TenantAttributesTest.java
+++ b/src/test/java/dev/sultanov/keycloak/multitenancy/TenantAttributesTest.java
@@ -223,4 +223,32 @@ public class TenantAttributesTest extends BaseIntegrationTest {
         assertThat(createdTenant.getAttributes())
                 .containsEntry("test", List.of(longValue));
     }
+
+    @Test
+    void shouldPreserveAttributesWhenUpdatingWithoutAttributesField() {
+        // given
+        var user = keycloakAdminClient.createVerifiedUser();
+        var tenantResource = user.createTenant();
+
+        var addAttributesRequest = new TenantRepresentation();
+        Map<String, List<String>> attributes = new HashMap<>();
+        attributes.put("department", List.of("Engineering"));
+        attributes.put("location", List.of("San Francisco"));
+        addAttributesRequest.setAttributes(attributes);
+        tenantResource.updateTenant(addAttributesRequest);
+
+        // when
+        var updateRequest = new TenantRepresentation();
+        updateRequest.setName("Updated-" + UUID.randomUUID());
+
+        try (var response = tenantResource.updateTenant(updateRequest)) {
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+        }
+
+        // then
+        var updatedTenant = tenantResource.toRepresentation();
+        assertThat(updatedTenant.getAttributes())
+                .containsEntry("department", List.of("Engineering"))
+                .containsEntry("location", List.of("San Francisco"));
+    }
 }


### PR DESCRIPTION
## Summary
Fixes the issue where updating a tenant without including the `attributes` field incorrectly removed all existing attributes.

## Changes
- Removed default initialization from `TenantRepresentation.attributes`
- Added test `shouldPreserveAttributesWhenUpdatingWithoutAttributesField()` to verify correct behavior

## Behavior
- **Before:** `attributes` always non-null → removed all attributes on PUT without field
- **After:** `attributes` can be null → preserves attributes when field omitted

Closes #87