### PR TITLE
fix: Skip review-tenant-invitations when email is missing or unverified

### DIFF
--- a/src/main/java/dev/sultanov/keycloak/multitenancy/authentication/requiredactions/ReviewTenantInvitations.java
+++ b/src/main/java/dev/sultanov/keycloak/multitenancy/authentication/requiredactions/ReviewTenantInvitations.java
@@ -37,17 +37,25 @@ public class ReviewTenantInvitations implements RequiredActionProvider, Required
         var realm = context.getRealm();
         var user = context.getUser();
         var provider = context.getSession().getProvider(TenantProvider.class);
-        if (user.getEmail() != null && user.isEmailVerified()) {
+
+        // Without a verified email we cannot match invitations reliably. Skip
+        // the challenge instead of falling through silently — leaving the
+        // required action unresolved stalls the flow and breaks downstream
+        // actions like select-active-tenant.
+        if (user.getEmail() == null || !user.isEmailVerified()) {
             log.debug("User email is missing or not verified, skipping challenge");
-            var invitations = provider.getTenantInvitationsStream(realm, user).collect(Collectors.toList());
-            if (invitations.isEmpty()) {
-                log.debug("No invitations found, challenge not required");
-                context.success();
-            } else {
-                log.debug("Invitations found, initializing challenge");
-                var challenge = context.form().setAttribute("data", TenantsBean.fromInvitations(invitations)).createForm("review-invitations.ftl");
-                context.challenge(challenge);
-            }
+            context.success();
+            return;
+        }
+
+        var invitations = provider.getTenantInvitationsStream(realm, user).collect(Collectors.toList());
+        if (invitations.isEmpty()) {
+            log.debug("No invitations found, challenge not required");
+            context.success();
+        } else {
+            log.debug("Invitations found, initializing challenge");
+            var challenge = context.form().setAttribute("data", TenantsBean.fromInvitations(invitations)).createForm("review-invitations.ftl");
+            context.challenge(challenge);
         }
     }
 


### PR DESCRIPTION
The required action's condition was inverted: real challenge/success
logic only ran when the email was both present and verified, while the
opposite branch fell through without calling context.success() or
context.challenge(). The action stayed unresolved, blocking downstream
required actions like select-active-tenant; the active_tenant session
note was never set, so token claims fell back to realm roles instead
of tenant-scoped ones.

Inverts the guard to an early skip: when the email is missing or
unverified, call context.success() and return. The log message now
matches the path it sits on.

Symptoms before the fix: a user with a pending invitation whose email
was unverified would log in and receive realm roles
(offline_access, uma_authorization, default-roles-<realm>) instead of
their tenant memberships and roles.