### PR TITLE
fix: Lock tenant-admin role and protect the last admin

### DIFF
--- a/src/main/java/dev/sultanov/keycloak/multitenancy/resource/TenantInvitationsResource.java
+++ b/src/main/java/dev/sultanov/keycloak/multitenancy/resource/TenantInvitationsResource.java
@@ -1,5 +1,7 @@
 package dev.sultanov.keycloak.multitenancy.resource;
 
+import static dev.sultanov.keycloak.multitenancy.util.Constants.TENANT_ADMIN_ROLE;
+import static dev.sultanov.keycloak.multitenancy.util.Constants.TENANT_USER_ROLE;
 import static org.keycloak.locale.LocaleSelectorProvider.USER_REQUEST_LOCALE;
 
 import dev.sultanov.keycloak.multitenancy.email.EmailRecipient;
@@ -24,7 +26,9 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
@@ -54,8 +58,10 @@ public class TenantInvitationsResource extends AbstractAdminResource<TenantAdmin
     @Operation(operationId = "createInvitation", summary = "Create invitation")
     @APIResponses({
             @APIResponse(responseCode = "201", description = "Created"),
+            @APIResponse(responseCode = "400", description = "Bad Request — invalid email or attempt to assign admin role"),
             @APIResponse(responseCode = "401", description = "Unauthorized"),
-            @APIResponse(responseCode = "403", description = "Forbidden")
+            @APIResponse(responseCode = "403", description = "Forbidden"),
+            @APIResponse(responseCode = "409", description = "Conflict — invitation or membership already exists")
     })
     public Response createInvitation(@RequestBody(required = true) TenantInvitationRepresentation request) {
         String email = request.getEmail();
@@ -73,8 +79,13 @@ public class TenantInvitationsResource extends AbstractAdminResource<TenantAdmin
             throw new ClientErrorException(String.format("%s is already a member of this organization.", email), Response.Status.CONFLICT);
         }
 
+        // Admin assignment is not allowed via invitation — only the tenant
+        // creator gets tenant-admin (see JpaTenantProvider#createTenant). All
+        // invited members default to tenant-user plus any service-level roles.
+        Set<String> normalizedRoles = normalizeAssignableRoles(request.getRoles());
+
         try {
-            TenantInvitationModel invitation = tenant.addInvitation(email, auth.getUser(), request.getRoles());
+            TenantInvitationModel invitation = tenant.addInvitation(email, auth.getUser(), normalizedRoles);
             TenantInvitationRepresentation representation = ModelMapper.toRepresentation(invitation);
 
             session.setAttribute(USER_REQUEST_LOCALE, request.getLocale());
@@ -136,6 +147,15 @@ public class TenantInvitationsResource extends AbstractAdminResource<TenantAdmin
         } else {
             throw new NotFoundException(String.format("No invitation with id %s", invitationId));
         }
+    }
+
+    private static Set<String> normalizeAssignableRoles(Set<String> requested) {
+        Set<String> roles = requested == null ? new HashSet<>() : new HashSet<>(requested);
+        if (roles.contains(TENANT_ADMIN_ROLE)) {
+            throw new BadRequestException("Role '" + TENANT_ADMIN_ROLE + "' cannot be assigned via invitation");
+        }
+        roles.add(TENANT_USER_ROLE);
+        return roles;
     }
 
     private static boolean isValidEmail(String email) {

--- a/src/main/java/dev/sultanov/keycloak/multitenancy/resource/TenantMembershipsResource.java
+++ b/src/main/java/dev/sultanov/keycloak/multitenancy/resource/TenantMembershipsResource.java
@@ -1,7 +1,13 @@
 package dev.sultanov.keycloak.multitenancy.resource;
 
+import static dev.sultanov.keycloak.multitenancy.util.Constants.TENANT_ADMIN_ROLE;
+import static dev.sultanov.keycloak.multitenancy.util.Constants.TENANT_USER_ROLE;
+
+import dev.sultanov.keycloak.multitenancy.model.TenantMembershipModel;
 import dev.sultanov.keycloak.multitenancy.model.TenantModel;
 import dev.sultanov.keycloak.multitenancy.resource.representation.TenantMembershipRepresentation;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
@@ -15,6 +21,8 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
@@ -70,6 +78,7 @@ public class TenantMembershipsResource extends AbstractAdminResource<TenantAdmin
     @Operation(operationId = "updateMembership", summary = "Update tenant membership")
     @APIResponses({
             @APIResponse(responseCode = "204", description = "No Content"),
+            @APIResponse(responseCode = "400", description = "Bad Request — attempt to grant admin role to a non-admin"),
             @APIResponse(responseCode = "401", description = "Unauthorized"),
             @APIResponse(responseCode = "403", description = "Forbidden"),
             @APIResponse(responseCode = "404", description = "Not Found")
@@ -80,10 +89,15 @@ public class TenantMembershipsResource extends AbstractAdminResource<TenantAdmin
             throw new NotFoundException("Membership not found");
         }
 
-        optionalMembership.get().updateRoles(request.getRoles());
+        // Admin role is implicit (creator-only) and cannot be changed via this
+        // endpoint. We strip any attempt to add or remove it from the payload
+        // and preserve the membership's current admin status.
+        TenantMembershipModel membership = optionalMembership.get();
+        Set<String> nextRoles = normalizeUpdatableRoles(membership.getRoles(), request.getRoles());
+        membership.updateRoles(nextRoles);
         adminEvent.operation(OperationType.UPDATE)
                 .resourcePath(session.getContext().getUri())
-                .representation(ModelMapper.toRepresentation(optionalMembership.get()))
+                .representation(ModelMapper.toRepresentation(membership))
                 .success();
 
         return Response.noContent().build();
@@ -96,9 +110,24 @@ public class TenantMembershipsResource extends AbstractAdminResource<TenantAdmin
             @APIResponse(responseCode = "204", description = "No Content"),
             @APIResponse(responseCode = "401", description = "Unauthorized"),
             @APIResponse(responseCode = "403", description = "Forbidden"),
-            @APIResponse(responseCode = "404", description = "Not Found")
+            @APIResponse(responseCode = "404", description = "Not Found"),
+            @APIResponse(responseCode = "409", description = "Conflict — cannot revoke the last workspace admin")
     })
     public Response revokeMembership(@PathParam("membershipId") String membershipId) {
+        var optionalMembership = tenant.getMembershipById(membershipId);
+        if (optionalMembership.isEmpty()) {
+            throw new NotFoundException(String.format("No membership with id %s", membershipId));
+        }
+
+        // Refuse to revoke the last tenant-admin. The only way to remove the
+        // sole admin is to delete the workspace itself.
+        if (optionalMembership.get().getRoles().contains(TENANT_ADMIN_ROLE)
+                && !hasOtherAdmin(membershipId)) {
+            throw new ClientErrorException(
+                    "Cannot revoke the last workspace admin. Delete the workspace instead.",
+                    Response.Status.CONFLICT);
+        }
+
         var revoked = tenant.revokeMembership(membershipId);
         if (revoked) {
             adminEvent.operation(OperationType.DELETE)
@@ -108,5 +137,31 @@ public class TenantMembershipsResource extends AbstractAdminResource<TenantAdmin
         } else {
             throw new NotFoundException(String.format("No membership with id %s", membershipId));
         }
+    }
+
+    private boolean hasOtherAdmin(String excludedMembershipId) {
+        return tenant.getMembershipsStream(0, Integer.MAX_VALUE)
+                .filter(m -> !m.getId().equals(excludedMembershipId))
+                .anyMatch(m -> m.getRoles().contains(TENANT_ADMIN_ROLE));
+    }
+
+    private static Set<String> normalizeUpdatableRoles(Set<String> currentRoles, Set<String> requestedRoles) {
+        Set<String> next = requestedRoles == null ? new HashSet<>() : new HashSet<>(requestedRoles);
+        boolean wasAdmin = currentRoles != null && currentRoles.contains(TENANT_ADMIN_ROLE);
+
+        if (next.contains(TENANT_ADMIN_ROLE) && !wasAdmin) {
+            throw new BadRequestException("Role '" + TENANT_ADMIN_ROLE + "' cannot be granted via this endpoint");
+        }
+
+        // Preserve admin status independently of the request: existing admins
+        // keep their role, non-admins cannot become admins.
+        next.remove(TENANT_ADMIN_ROLE);
+        if (wasAdmin) {
+            next.add(TENANT_ADMIN_ROLE);
+        } else {
+            // Non-admins always carry the workspace-member baseline.
+            next.add(TENANT_USER_ROLE);
+        }
+        return next;
     }
 }


### PR DESCRIPTION
The REST resource layer trusted the role payload verbatim, which let any admin promote themselves or others to tenant-admin via PATCH /memberships, include the admin role in an invitation, or revoke the sole admin and leave the tenant orphaned.

- POST /tenants/{id}/invitations now rejects payloads that include tenant-admin (400) and silently injects tenant-user so every invited member carries the workspace baseline role.
- PATCH /tenants/{id}/memberships/{id} preserves the membership's existing admin status instead of writing the payload through, and enforces the same tenant-user baseline for non-admins.
- DELETE /tenants/{id}/memberships/{id} refuses to revoke the last remaining tenant-admin with 409; the only way to remove the sole admin is to delete the workspace itself.

OpenAPI @APIResponses annotations updated so generated clients see the new 400/409 paths.